### PR TITLE
fix: add newEntities to VerificationResult for pipeline decoupling (#13)

### DIFF
--- a/packages/indexer-v2/src/core/batchContext.ts
+++ b/packages/indexer-v2/src/core/batchContext.ts
@@ -103,7 +103,7 @@ export class BatchContext implements IBatchContext {
   getVerified(category: EntityCategory): VerificationResult {
     const result = this.verificationResults.get(category);
     if (!result) {
-      return { new: new Set(), valid: new Set(), invalid: new Set() };
+      return { new: new Set(), valid: new Set(), invalid: new Set(), newEntities: new Map() };
     }
     return result;
   }

--- a/packages/indexer-v2/src/core/types.ts
+++ b/packages/indexer-v2/src/core/types.ts
@@ -34,6 +34,8 @@ export interface VerificationResult {
   valid: Set<string>;
   /** Addresses that failed interface checks */
   invalid: Set<string>;
+  /** Newly created entity instances to persist, keyed by address */
+  newEntities: Map<string, { id: string }>;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `newEntities: Map<string, { id: string }>` field to `VerificationResult` interface in `core/types.ts`
- Updates `BatchContext.getVerified()` default return to include empty `newEntities` map
- This enables the pipeline to persist newly verified entities generically (iterating over verification results) instead of reading from hardcoded BatchContext keys (`'CoreUniversalProfile'`, `'CoreDigitalAsset'`, `'CoreNFT'`)

## Context

Review of PR #64 (Pipeline Orchestrator) identified that `persistCoreEntities()` was coupled to magic strings. This change moves entity instances into `VerificationResult` so the pipeline stays truly generic.

**Merge before**: PR #65 (verification) and PR #64 (pipeline), which will be updated to use `newEntities`.

Refs #13