### PR TITLE
feat: Executed (ERC725X) event plugin (#19)

### DIFF
--- a/packages/indexer-v2/src/core/types.ts
+++ b/packages/indexer-v2/src/core/types.ts
@@ -13,6 +13,8 @@ export type Block = BlockData<FieldSelection>;
 
 export type Context = DataHandlerContext<Store, FieldSelection>;
 
+export type { Log };
+
 // ---------------------------------------------------------------------------
 // Entity categories for address verification
 // ---------------------------------------------------------------------------

--- a/packages/indexer-v2/src/plugins/events/executed.plugin.ts
+++ b/packages/indexer-v2/src/plugins/events/executed.plugin.ts
@@ -1,0 +1,91 @@
+/**
+ * Executed (ERC725X) event plugin.
+ *
+ * Handles the `Executed(uint256,address,uint256,bytes4)` event emitted
+ * by Universal Profiles when they execute operations via ERC725X.
+ *
+ * The emitting address is tracked as a UniversalProfile candidate.
+ * During populate, entities from unverified UPs are filtered out and
+ * verified UPs are linked via the `universalProfile` relation.
+ *
+ * Port from v1:
+ *   - scanner.ts L160-163 (event matching)
+ *   - utils/executed/index.ts (extract + populate)
+ */
+import { v4 as uuidv4 } from 'uuid';
+
+import { ERC725X } from '@chillwhales/abi';
+import { Executed, UniversalProfile } from '@chillwhales/typeorm';
+import { Store } from '@subsquid/typeorm-store';
+
+import { Block, EntityCategory, EventPlugin, IBatchContext, Log } from '@/core/types';
+import { decodeOperationType } from '@/utils';
+
+// Entity type key used in the BatchContext entity bag
+const ENTITY_TYPE = 'Executed';
+
+const ExecutedPlugin: EventPlugin = {
+  name: 'executed',
+  topic0: ERC725X.events.Executed.topic,
+  requiresVerification: [EntityCategory.UniversalProfile],
+
+  // ---------------------------------------------------------------------------
+  // Phase 1: EXTRACT
+  // ---------------------------------------------------------------------------
+
+  extract(log: Log, block: Block, ctx: IBatchContext): void {
+    const { timestamp, height } = block.header;
+    const { address, logIndex, transactionIndex } = log;
+    const { operationType, value, target, selector } = ERC725X.events.Executed.decode(log);
+
+    const entity = new Executed({
+      id: uuidv4(),
+      timestamp: new Date(timestamp),
+      blockNumber: height,
+      logIndex,
+      transactionIndex,
+      address,
+      decodedOperationType: decodeOperationType(operationType),
+      operationType,
+      value,
+      target,
+      selector,
+    });
+
+    ctx.addEntity(ENTITY_TYPE, entity.id, entity);
+
+    // The emitting address is a Universal Profile
+    ctx.trackAddress(EntityCategory.UniversalProfile, address);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 3: POPULATE
+  // ---------------------------------------------------------------------------
+
+  populate(ctx: IBatchContext): void {
+    const entities = ctx.getEntities<Executed>(ENTITY_TYPE);
+
+    for (const [id, entity] of entities) {
+      if (ctx.isValid(EntityCategory.UniversalProfile, entity.address)) {
+        // Link to the verified Universal Profile
+        entity.universalProfile = new UniversalProfile({ id: entity.address });
+      } else {
+        // Emitting address is not a verified UP — remove the entity
+        ctx.removeEntity(ENTITY_TYPE, id);
+      }
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 4: PERSIST
+  // ---------------------------------------------------------------------------
+
+  async persist(store: Store, ctx: IBatchContext): Promise<void> {
+    const entities = ctx.getEntities<Executed>(ENTITY_TYPE);
+    if (entities.size === 0) return;
+
+    await store.insert([...entities.values()]);
+  },
+};
+
+export default ExecutedPlugin;

--- a/packages/indexer-v2/src/utils/index.ts
+++ b/packages/indexer-v2/src/utils/index.ts
@@ -1,4 +1,28 @@
+import { OperationType } from '@chillwhales/typeorm';
+
 export function isNumeric(value: string) {
   if (typeof value != 'string') return false;
   return !isNaN(value as any) && !isNaN(parseFloat(value));
+}
+
+/**
+ * Map ERC725X operation type integer to the OperationType enum.
+ *
+ * @see https://docs.lukso.tech/standards/lsp-background/erc725/#erc725x
+ */
+export function decodeOperationType(operationType: bigint): OperationType | null {
+  switch (operationType) {
+    case 0n:
+      return OperationType.CALL;
+    case 1n:
+      return OperationType.CREATE;
+    case 2n:
+      return OperationType.CREATE2;
+    case 3n:
+      return OperationType.DELEGATECALL;
+    case 4n:
+      return OperationType.STATICCALL;
+    default:
+      return null;
+  }
 }


### PR DESCRIPTION
## Summary
- Implements the **Executed** (ERC725X) event plugin — first Phase 2 plugin
- Self-contained `executed.plugin.ts` implementing the `EventPlugin` interface
- Adds `decodeOperationType` utility to `utils/index.ts`
- Exports `Log` type from `core/types.ts` (needed by all event plugins)

## What it does
| Phase | Behavior |
|-------|----------|
| **Extract** | Decodes `Executed(uint256,address,uint256,bytes4)` from log, creates `Executed` entity with UUID, tracks emitting address as `UniversalProfile` |
| **Populate** | Links entity to verified UP via `universalProfile` relation; removes entities from unverified addresses |
| **Persist** | `store.insert()` — append-only (each event is a unique row) |

## Files Changed
| File | Change |
|------|--------|
| `plugins/events/executed.plugin.ts` | **New** — Executed event plugin |
| `utils/index.ts` | Add `decodeOperationType()` utility (ported from v1) |
| `core/types.ts` | Export `Log` type for plugin use |

## Port from v1
- `scanner.ts` L160-163 (event matching)
- `utils/executed/index.ts` (extract + populate)
- `utils/index.ts` `decodeOperationType()` (refactored from ternary chain to switch)

Closes #19