### PR TITLE
feat: LSP8 Transfer event plugin (#21)

### DIFF
--- a/packages/indexer-v2/src/plugins/events/lsp8Transfer.plugin.ts
+++ b/packages/indexer-v2/src/plugins/events/lsp8Transfer.plugin.ts
@@ -1,0 +1,169 @@
+/**
+ * LSP8 Transfer event plugin.
+ *
+ * Handles the `Transfer(address,address,address,bytes32,bool,bytes)` event
+ * emitted by LSP8 identifiable (NFT) digital assets.
+ *
+ * LSP8 vs LSP7 distinction: Different event signatures produce different
+ * topic0 hashes. LSP8 has `bytes32 tokenId` (indexed), while LSP7 has
+ * `uint256 amount` (non-indexed). This plugin only handles the LSP8 variant.
+ *
+ * In addition to creating Transfer entities, this plugin also creates NFT
+ * entities for mint (from === 0x0) and burn (to === 0x0) events.
+ *
+ * Tracked addresses:
+ *   - `from` / `to` → UniversalProfile candidates
+ *   - `log.address` → DigitalAsset candidate
+ *
+ * NFT verification is handled differently from UP/DA: NFTs don't use
+ * supportsInterface — their parent DA's LSP8 check covers them. NFT
+ * entities are created directly and upserted during persist.
+ *
+ * Port from v1:
+ *   - scanner.ts L440-452 (event matching + NFT extraction)
+ *   - utils/transfer/index.ts (extract LSP8 branch + populate)
+ *   - utils/transfer/nft.ts (mint/burn NFT creation)
+ */
+import { v4 as uuidv4 } from 'uuid';
+import { zeroAddress } from 'viem';
+
+import { LSP8IdentifiableDigitalAsset } from '@chillwhales/abi';
+import { DigitalAsset, NFT, Transfer } from '@chillwhales/typeorm';
+import { Store } from '@subsquid/typeorm-store';
+
+import { Block, EntityCategory, EventPlugin, IBatchContext, Log } from '@/core/types';
+import { generateTokenId } from '@/utils';
+
+// Entity type keys used in the BatchContext entity bag
+const TRANSFER_TYPE = 'LSP8Transfer';
+const NFT_TYPE = 'NFT';
+
+const LSP8TransferPlugin: EventPlugin = {
+  name: 'lsp8Transfer',
+  topic0: LSP8IdentifiableDigitalAsset.events.Transfer.topic,
+  requiresVerification: [EntityCategory.UniversalProfile, EntityCategory.DigitalAsset],
+
+  // ---------------------------------------------------------------------------
+  // Phase 1: EXTRACT
+  // ---------------------------------------------------------------------------
+
+  extract(log: Log, block: Block, ctx: IBatchContext): void {
+    const { timestamp, height } = block.header;
+    const { address, logIndex, transactionIndex } = log;
+    const { operator, from, to, tokenId, force, data } =
+      LSP8IdentifiableDigitalAsset.events.Transfer.decode(log);
+
+    const nftId = generateTokenId({ address, tokenId });
+
+    // Create Transfer entity (amount is always 1 for LSP8)
+    const transfer = new Transfer({
+      id: uuidv4(),
+      timestamp: new Date(timestamp),
+      blockNumber: height,
+      logIndex,
+      transactionIndex,
+      address,
+      operator,
+      from,
+      to,
+      amount: 1n,
+      tokenId,
+      force,
+      data,
+      nft: new NFT({ id: nftId, tokenId, address }),
+    });
+
+    ctx.addEntity(TRANSFER_TYPE, transfer.id, transfer);
+
+    // Create NFT entity for mint/burn events
+    if (from === zeroAddress) {
+      ctx.addEntity(
+        NFT_TYPE,
+        nftId,
+        new NFT({
+          id: nftId,
+          tokenId,
+          address,
+          digitalAsset: new DigitalAsset({ id: address, address }),
+          isMinted: true,
+          isBurned: false,
+        }),
+      );
+    } else if (to === zeroAddress) {
+      ctx.addEntity(
+        NFT_TYPE,
+        nftId,
+        new NFT({
+          id: nftId,
+          tokenId,
+          address,
+          digitalAsset: new DigitalAsset({ id: address, address }),
+          isMinted: false,
+          isBurned: true,
+        }),
+      );
+    }
+
+    // Track from/to as UP candidates, contract address as DA candidate
+    ctx.trackAddress(EntityCategory.UniversalProfile, from);
+    ctx.trackAddress(EntityCategory.UniversalProfile, to);
+    ctx.trackAddress(EntityCategory.DigitalAsset, address);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 3: POPULATE
+  // ---------------------------------------------------------------------------
+
+  populate(ctx: IBatchContext): void {
+    // Populate Transfer entities — link to verified DigitalAsset
+    const transfers = ctx.getEntities<Transfer>(TRANSFER_TYPE);
+
+    for (const [id, entity] of transfers) {
+      if (ctx.isValid(EntityCategory.DigitalAsset, entity.address)) {
+        entity.digitalAsset = new DigitalAsset({ id: entity.address });
+
+        // Enrich the Transfer's NFT reference with the DA relation
+        if (entity.nft) {
+          entity.nft = new NFT({
+            ...entity.nft,
+            digitalAsset: new DigitalAsset({ id: entity.address }),
+          });
+        }
+      } else {
+        // Contract is not a verified DigitalAsset — remove the transfer
+        ctx.removeEntity(TRANSFER_TYPE, id);
+      }
+    }
+
+    // Populate NFT entities — link to verified DigitalAsset
+    const nfts = ctx.getEntities<NFT>(NFT_TYPE);
+
+    for (const [id, entity] of nfts) {
+      if (ctx.isValid(EntityCategory.DigitalAsset, entity.address)) {
+        entity.digitalAsset = new DigitalAsset({ id: entity.address });
+      } else {
+        ctx.removeEntity(NFT_TYPE, id);
+      }
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 4: PERSIST
+  // ---------------------------------------------------------------------------
+
+  async persist(store: Store, ctx: IBatchContext): Promise<void> {
+    // Upsert NFTs first (Transfers have FK references to NFTs)
+    const nfts = ctx.getEntities<NFT>(NFT_TYPE);
+    if (nfts.size > 0) {
+      await store.upsert([...nfts.values()]);
+    }
+
+    // Insert Transfer entities
+    const transfers = ctx.getEntities<Transfer>(TRANSFER_TYPE);
+    if (transfers.size > 0) {
+      await store.insert([...transfers.values()]);
+    }
+  },
+};
+
+export default LSP8TransferPlugin;

--- a/packages/indexer-v2/src/utils/index.ts
+++ b/packages/indexer-v2/src/utils/index.ts
@@ -10,6 +10,26 @@ export function isNumeric(value: string) {
  *
  * @see https://docs.lukso.tech/standards/lsp-background/erc725/#erc725x
  */
+/**
+ * Generate a deterministic NFT entity ID from contract address and tokenId.
+ *
+ * Format: `"{address} - {tokenId}"`
+ */
+export function generateTokenId({
+  address,
+  tokenId,
+}: {
+  address: string;
+  tokenId: string;
+}): string {
+  return `${address} - ${tokenId}`;
+}
+
+/**
+ * Map ERC725X operation type integer to the OperationType enum.
+ *
+ * @see https://docs.lukso.tech/standards/lsp-background/erc725/#erc725x
+ */
 export function decodeOperationType(operationType: bigint): OperationType | null {
   switch (operationType) {
     case 0n:


### PR DESCRIPTION
## Summary
- Implements the **LSP8 Transfer** event plugin — handles NFT (identifiable) token transfers
- Self-contained `lsp8Transfer.plugin.ts` implementing the `EventPlugin` interface
- Adds `generateTokenId` utility to `utils/index.ts`

## What it does
| Phase | Behavior |
|-------|----------|
| **Extract** | Decodes `Transfer(address,address,address,bytes32,bool,bytes)` from LSP8 events. Creates `Transfer` entity (amount=1n, tokenId set, nft linked). Creates `NFT` entity for mint/burn events. Tracks `from`/`to` as UP candidates, contract `address` as DA candidate |
| **Populate** | Links Transfer + NFT to verified `DigitalAsset`; removes entities from unverified contracts |
| **Persist** | `store.upsert()` NFTs first (mint/burn updates same entity ID), then `store.insert()` Transfers |

## NFT mint/burn detection
| Condition | Result |
|-----------|--------|
| `from === 0x0` | Mint — `NFT { isMinted: true, isBurned: false }` |
| `to === 0x0` | Burn — `NFT { isMinted: false, isBurned: true }` |
| Regular transfer | No NFT entity created (only Transfer) |

## LSP8 vs LSP7 distinction
- Different topic0: `0xb333c813...` (LSP8) vs `0x3997e418...` (LSP7)
- LSP8: `bytes32 tokenId` (indexed), `amount` hardcoded to `1n`, `nft` relation set
- LSP7: `uint256 amount` (non-indexed), no `tokenId`/`nft` — handled by PR #69

## Files Changed
| File | Change |
|------|--------|
| `plugins/events/lsp8Transfer.plugin.ts` | **New** — LSP8 Transfer event plugin |
| `utils/index.ts` | Add `generateTokenId()` utility |

## Port from v1
- `scanner.ts` L440-452 (event matching + NFT extraction)
- `utils/transfer/index.ts` extract() LSP8 branch + populate()
- `utils/transfer/nft.ts` (mint/burn NFT creation)

Closes #21