### PR TITLE
feat: OwnershipTransferred (LSP14) event plugin (#23)

### DIFF
--- a/packages/indexer-v2/src/plugins/events/ownershipTransferred.plugin.ts
+++ b/packages/indexer-v2/src/plugins/events/ownershipTransferred.plugin.ts
@@ -1,0 +1,155 @@
+/**
+ * OwnershipTransferred (LSP14) event plugin.
+ *
+ * Handles the `OwnershipTransferred(address,address)` event emitted by
+ * Universal Profiles and Digital Assets when ownership changes.
+ *
+ * The emitting address is tracked as BOTH a UniversalProfile and DigitalAsset
+ * candidate (either type can emit this event).
+ *
+ * The `handle()` phase upserts `UniversalProfileOwner` and `DigitalAssetOwner`
+ * records to track the current owner of each contract.
+ *
+ * Port from v1:
+ *   - scanner.ts L563-568 (event matching)
+ *   - utils/ownershipTransferred/index.ts (extract + populate)
+ *   - handlers/ownershipTransferredHandler.ts (owner record upsert)
+ */
+import { v4 as uuidv4 } from 'uuid';
+
+import { LSP14Ownable2Step } from '@chillwhales/abi';
+import {
+  DigitalAsset,
+  DigitalAssetOwner,
+  OwnershipTransferred,
+  UniversalProfile,
+  UniversalProfileOwner,
+} from '@chillwhales/typeorm';
+import { Store } from '@subsquid/typeorm-store';
+
+import {
+  Block,
+  EntityCategory,
+  EventPlugin,
+  HandlerContext,
+  IBatchContext,
+  Log,
+} from '@/core/types';
+
+// Entity type key used in the BatchContext entity bag
+const ENTITY_TYPE = 'OwnershipTransferred';
+
+const OwnershipTransferredPlugin: EventPlugin = {
+  name: 'ownershipTransferred',
+  topic0: LSP14Ownable2Step.events.OwnershipTransferred.topic,
+  requiresVerification: [EntityCategory.UniversalProfile, EntityCategory.DigitalAsset],
+
+  // ---------------------------------------------------------------------------
+  // Phase 1: EXTRACT
+  // ---------------------------------------------------------------------------
+
+  extract(log: Log, block: Block, ctx: IBatchContext): void {
+    const { timestamp, height } = block.header;
+    const { address, logIndex, transactionIndex } = log;
+    const { previousOwner, newOwner } = LSP14Ownable2Step.events.OwnershipTransferred.decode(log);
+
+    const entity = new OwnershipTransferred({
+      id: uuidv4(),
+      timestamp: new Date(timestamp),
+      blockNumber: height,
+      logIndex,
+      transactionIndex,
+      address,
+      previousOwner,
+      newOwner,
+    });
+
+    ctx.addEntity(ENTITY_TYPE, entity.id, entity);
+
+    // The emitting address could be either a UP or a DA
+    ctx.trackAddress(EntityCategory.UniversalProfile, address);
+    ctx.trackAddress(EntityCategory.DigitalAsset, address);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 3: POPULATE
+  // ---------------------------------------------------------------------------
+
+  populate(ctx: IBatchContext): void {
+    const entities = ctx.getEntities<OwnershipTransferred>(ENTITY_TYPE);
+
+    for (const [id, entity] of entities) {
+      const isUP = ctx.isValid(EntityCategory.UniversalProfile, entity.address);
+      const isDA = ctx.isValid(EntityCategory.DigitalAsset, entity.address);
+
+      if (isUP) {
+        entity.universalProfile = new UniversalProfile({ id: entity.address });
+      }
+      if (isDA) {
+        entity.digitalAsset = new DigitalAsset({ id: entity.address });
+      }
+
+      // If neither UP nor DA, remove the entity
+      if (!isUP && !isDA) {
+        ctx.removeEntity(ENTITY_TYPE, id);
+      }
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 4: PERSIST
+  // ---------------------------------------------------------------------------
+
+  async persist(store: Store, ctx: IBatchContext): Promise<void> {
+    const entities = ctx.getEntities<OwnershipTransferred>(ENTITY_TYPE);
+    if (entities.size === 0) return;
+
+    await store.insert([...entities.values()]);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 5: HANDLE — Update owner records
+  // ---------------------------------------------------------------------------
+
+  async handle(hctx: HandlerContext): Promise<void> {
+    const entities = hctx.batchCtx.getEntities<OwnershipTransferred>(ENTITY_TYPE);
+    if (entities.size === 0) return;
+
+    const upOwners = new Map<string, UniversalProfileOwner>();
+    const daOwners = new Map<string, DigitalAssetOwner>();
+
+    for (const entity of entities.values()) {
+      if (entity.universalProfile) {
+        upOwners.set(
+          entity.address,
+          new UniversalProfileOwner({
+            id: entity.address,
+            timestamp: entity.timestamp,
+            address: entity.newOwner,
+            universalProfile: entity.universalProfile,
+          }),
+        );
+      }
+      if (entity.digitalAsset) {
+        daOwners.set(
+          entity.address,
+          new DigitalAssetOwner({
+            id: entity.address,
+            timestamp: entity.timestamp,
+            address: entity.newOwner,
+            digitalAsset: entity.digitalAsset,
+          }),
+        );
+      }
+    }
+
+    if (upOwners.size > 0) {
+      await hctx.store.upsert([...upOwners.values()]);
+    }
+    if (daOwners.size > 0) {
+      await hctx.store.upsert([...daOwners.values()]);
+    }
+  },
+};
+
+export default OwnershipTransferredPlugin;


### PR DESCRIPTION
## Summary
- Implements the **OwnershipTransferred** (LSP14) event plugin — first plugin with a `handle()` phase
- Self-contained `ownershipTransferred.plugin.ts` implementing the full `EventPlugin` interface including all 4 phases

## What it does
| Phase | Behavior |
|-------|----------|
| **Extract** | Decodes `OwnershipTransferred(address,address)` from LSP14 events. Creates entity with UUID. Tracks emitting address as **both** UP and DA candidate |
| **Populate** | Links to verified `UniversalProfile` and/or `DigitalAsset`; removes if neither |
| **Persist** | `store.insert()` — append-only event log |
| **Handle** | Upserts `UniversalProfileOwner` and `DigitalAssetOwner` records keyed by contract address, setting `address = newOwner`. Map deduplicates within batch (last transfer wins) |

## Owner tracking
The handle phase maintains two "current owner" tables:

| Entity | PK | Key field | Relation |
|--------|----|-----------|----------|
| `UniversalProfileOwner` | contract address | `address` = new owner | OneToOne → UP |
| `DigitalAssetOwner` | contract address | `address` = new owner | OneToOne → DA |

Both use `store.upsert()` — ownership transfers update the existing record rather than creating new rows.

## Files Changed
| File | Change |
|------|--------|
| `plugins/events/ownershipTransferred.plugin.ts` | **New** — OwnershipTransferred event plugin with handler |

## Port from v1
- `scanner.ts` L563-568 (event matching — tracks address as both UP and DA)
- `utils/ownershipTransferred/index.ts` (extract + populate)
- `handlers/ownershipTransferredHandler.ts` (owner record upsert)

Closes #23