### PR TITLE
feat: DeployedContracts (LSP23) event plugin (#26)

### DIFF
--- a/packages/indexer-v2/src/plugins/events/deployedContracts.plugin.ts
+++ b/packages/indexer-v2/src/plugins/events/deployedContracts.plugin.ts
@@ -1,0 +1,94 @@
+/**
+ * DeployedContracts (LSP23) event plugin.
+ *
+ * Handles the `DeployedContracts(address,address,(bytes32,uint256,bytes),
+ * (uint256,bytes,bool,bytes),address,bytes)` event emitted by the LSP23
+ * LinkedContractsFactory when new contracts are deployed via CREATE.
+ *
+ * Contract-scoped: only processes logs from the LSP23 factory address
+ * starting at block 1143651.
+ *
+ * This event does NOT trigger UP/DA verification — the deployed contracts
+ * are recorded as-is. The nested struct fields (PrimaryContractDeployment,
+ * SecondaryContractDeployment) are stored as JSONB columns.
+ *
+ * Port from v1:
+ *   - scanner.ts L491-524 (inline extraction, no separate extract/populate)
+ */
+import { v4 as uuidv4 } from 'uuid';
+
+import { LSP23LinkedContractsFactory } from '@chillwhales/abi';
+import {
+  DeployedContracts,
+  PrimaryContractDeployment,
+  SecondaryContractDeployment,
+} from '@chillwhales/typeorm';
+import { Store } from '@subsquid/typeorm-store';
+
+import { LSP23_ADDRESS } from '@/constants';
+import { Block, EventPlugin, IBatchContext, Log } from '@/core/types';
+
+// Entity type key used in the BatchContext entity bag
+const ENTITY_TYPE = 'DeployedContracts';
+
+const DeployedContractsPlugin: EventPlugin = {
+  name: 'deployedContracts',
+  topic0: LSP23LinkedContractsFactory.events.DeployedContracts.topic,
+  contractFilter: { address: LSP23_ADDRESS, fromBlock: 1143651 },
+  requiresVerification: [],
+
+  // ---------------------------------------------------------------------------
+  // Phase 1: EXTRACT
+  // ---------------------------------------------------------------------------
+
+  extract(log: Log, block: Block, ctx: IBatchContext): void {
+    const { timestamp, height } = block.header;
+    const { address, logIndex, transactionIndex } = log;
+    const {
+      primaryContract,
+      secondaryContract,
+      primaryContractDeployment,
+      secondaryContractDeployment,
+      postDeploymentModule,
+      postDeploymentModuleCalldata,
+    } = LSP23LinkedContractsFactory.events.DeployedContracts.decode(log);
+
+    const entity = new DeployedContracts({
+      id: uuidv4(),
+      timestamp: new Date(timestamp),
+      blockNumber: height,
+      logIndex,
+      transactionIndex,
+      address,
+      primaryContract,
+      secondaryContract,
+      primaryContractDeployment: new PrimaryContractDeployment(primaryContractDeployment),
+      secondaryContractDeployment: new SecondaryContractDeployment(secondaryContractDeployment),
+      postDeploymentModule,
+      postDeploymentModuleCalldata,
+    });
+
+    ctx.addEntity(ENTITY_TYPE, entity.id, entity);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 3: POPULATE — No-op (no verification required)
+  // ---------------------------------------------------------------------------
+
+  populate(): void {
+    // No verification or relational linking needed
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 4: PERSIST
+  // ---------------------------------------------------------------------------
+
+  async persist(store: Store, ctx: IBatchContext): Promise<void> {
+    const entities = ctx.getEntities<DeployedContracts>(ENTITY_TYPE);
+    if (entities.size === 0) return;
+
+    await store.insert([...entities.values()]);
+  },
+};
+
+export default DeployedContractsPlugin;


### PR DESCRIPTION
## Summary
- Implements the **DeployedContracts** (LSP23) event plugin
- Self-contained `deployedContracts.plugin.ts` — extract + persist only (no verification)

## What it does
| Phase | Behavior |
|-------|----------|
| **Extract** | Decodes `DeployedContracts(address,address,struct,struct,address,bytes)` from LSP23 factory. Creates entity with UUID, wraps nested structs in `PrimaryContractDeployment` / `SecondaryContractDeployment` |
| **Populate** | No-op — no UP/DA verification needed |
| **Persist** | `store.insert()` — append-only |

## Contract scope
- **Address**: `0x2300000A84D25dF63081feAa37ba6b62C4c89a30` (LSP23 factory)
- **From block**: `1143651`

## JSONB nested structs
| Struct | Fields |
|--------|--------|
| `PrimaryContractDeployment` | `salt`, `fundingAmount`, `creationBytecode` |
| `SecondaryContractDeployment` | `fundingAmount`, `creationBytecode`, `addPrimaryContractAddress`, `extraConstructorParams` |

## Files Changed
| File | Change |
|------|--------|
| `plugins/events/deployedContracts.plugin.ts` | **New** — DeployedContracts event plugin |

## Port from v1
- `scanner.ts` L491-524 (inline extraction — v1 had no separate extract/populate functions)

Closes #26