### PR TITLE
feat: DataChanged meta-plugin with dataKey routing (#29)

### DIFF
--- a/packages/indexer-v2/src/core/index.ts
+++ b/packages/indexer-v2/src/core/index.ts
@@ -2,6 +2,7 @@
 export * from './batchContext';
 export * from './metadataWorkerPool';
 export * from './pipeline';
+export * from './pluginHelpers';
 export * from './registry';
 export * from './types';
 export * from './verification';

--- a/packages/indexer-v2/src/core/pluginHelpers.ts
+++ b/packages/indexer-v2/src/core/pluginHelpers.ts
@@ -1,0 +1,130 @@
+/**
+ * Shared populate and persist helpers for plugins.
+ *
+ * These extract the most common patterns found across event plugins:
+ *   - Populate: validate addresses by category, link to parent, remove invalid
+ *   - Persist: insert or upsert entity maps from BatchContext
+ *
+ * Plugins import these helpers instead of duplicating the same loops.
+ */
+import { DigitalAsset, NFT, UniversalProfile } from '@chillwhales/typeorm';
+import { Store } from '@subsquid/typeorm-store';
+
+import { EntityCategory, IBatchContext } from './types';
+
+// ---------------------------------------------------------------------------
+// Populate helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Populate entities that require a verified UniversalProfile.
+ *
+ * Links `entity.universalProfile` for valid addresses, removes entity if invalid.
+ * Used by: Executed, UniversalReceiver.
+ */
+export function populateByUP<T extends { address: string; universalProfile?: unknown }>(
+  ctx: IBatchContext,
+  entityType: string,
+): void {
+  const entities = ctx.getEntities<T>(entityType);
+
+  for (const [id, entity] of entities) {
+    if (ctx.isValid(EntityCategory.UniversalProfile, entity.address)) {
+      entity.universalProfile = new UniversalProfile({ id: entity.address });
+    } else {
+      ctx.removeEntity(entityType, id);
+    }
+  }
+}
+
+/**
+ * Populate entities that require a verified DigitalAsset.
+ *
+ * Links `entity.digitalAsset` for valid addresses, removes entity if invalid.
+ * Used by: LSP7Transfer, and the NFT sub-loop in LSP8Transfer/TokenIdDataChanged.
+ */
+export function populateByDA<T extends { address: string; digitalAsset?: unknown }>(
+  ctx: IBatchContext,
+  entityType: string,
+): void {
+  const entities = ctx.getEntities<T>(entityType);
+
+  for (const [id, entity] of entities) {
+    if (ctx.isValid(EntityCategory.DigitalAsset, entity.address)) {
+      entity.digitalAsset = new DigitalAsset({ id: entity.address });
+    } else {
+      ctx.removeEntity(entityType, id);
+    }
+  }
+}
+
+/**
+ * Populate entities that may belong to either a UniversalProfile or DigitalAsset.
+ *
+ * Links whichever parent(s) the address verified as. Removes entity if neither.
+ * An address can be both a UP and a DA.
+ * Used by: OwnershipTransferred, DataChanged.
+ */
+export function populateByUPAndDA<
+  T extends { address: string; universalProfile?: unknown; digitalAsset?: unknown },
+>(ctx: IBatchContext, entityType: string): void {
+  const entities = ctx.getEntities<T>(entityType);
+
+  for (const [id, entity] of entities) {
+    const isUP = ctx.isValid(EntityCategory.UniversalProfile, entity.address);
+    const isDA = ctx.isValid(EntityCategory.DigitalAsset, entity.address);
+
+    if (!isUP && !isDA) {
+      ctx.removeEntity(entityType, id);
+      continue;
+    }
+
+    entity.universalProfile = isUP ? new UniversalProfile({ id: entity.address }) : null;
+    entity.digitalAsset = isDA ? new DigitalAsset({ id: entity.address }) : null;
+  }
+}
+
+/**
+ * Populate NFT entities — link to verified DigitalAsset or remove.
+ *
+ * Identical loop used by LSP8Transfer and TokenIdDataChanged.
+ */
+export function populateNFTs(ctx: IBatchContext, nftType: string = 'NFT'): void {
+  populateByDA<NFT>(ctx, nftType);
+}
+
+// ---------------------------------------------------------------------------
+// Persist helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert entities from BatchContext into the store (append-only).
+ *
+ * Used by most plugins for event log entities with UUID ids.
+ */
+export async function insertEntities<T extends { id: string }>(
+  store: Store,
+  ctx: IBatchContext,
+  entityType: string,
+): Promise<void> {
+  const entities = ctx.getEntities<T>(entityType);
+  if (entities.size > 0) {
+    await store.insert([...entities.values()]);
+  }
+}
+
+/**
+ * Upsert entities from BatchContext into the store.
+ *
+ * Used for entities with deterministic ids (e.g. NFTs, Followers).
+ */
+export async function upsertEntities<T extends { id: string }>(
+  store: Store,
+  ctx: IBatchContext,
+  entityType: string,
+): Promise<void> {
+  const entities = ctx.getEntities<T>(entityType);
+  if (entities.size > 0) {
+    await store.upsert([...entities.values()]);
+  }
+}

--- a/packages/indexer-v2/src/plugins/events/deployedContracts.plugin.ts
+++ b/packages/indexer-v2/src/plugins/events/deployedContracts.plugin.ts
@@ -26,6 +26,7 @@ import {
 import { Store } from '@subsquid/typeorm-store';
 
 import { LSP23_ADDRESS } from '@/constants';
+import { insertEntities } from '@/core/pluginHelpers';
 import { Block, EventPlugin, IBatchContext, Log } from '@/core/types';
 
 // Entity type key used in the BatchContext entity bag
@@ -84,10 +85,7 @@ const DeployedContractsPlugin: EventPlugin = {
   // ---------------------------------------------------------------------------
 
   async persist(store: Store, ctx: IBatchContext): Promise<void> {
-    const entities = ctx.getEntities<DeployedContracts>(ENTITY_TYPE);
-    if (entities.size === 0) return;
-
-    await store.insert([...entities.values()]);
+    await insertEntities(store, ctx, ENTITY_TYPE);
   },
 };
 

--- a/packages/indexer-v2/src/plugins/events/deployedProxies.plugin.ts
+++ b/packages/indexer-v2/src/plugins/events/deployedProxies.plugin.ts
@@ -26,6 +26,7 @@ import {
 import { Store } from '@subsquid/typeorm-store';
 
 import { LSP23_ADDRESS } from '@/constants';
+import { insertEntities } from '@/core/pluginHelpers';
 import { Block, EventPlugin, IBatchContext, Log } from '@/core/types';
 
 // Entity type key used in the BatchContext entity bag
@@ -88,10 +89,7 @@ const DeployedProxiesPlugin: EventPlugin = {
   // ---------------------------------------------------------------------------
 
   async persist(store: Store, ctx: IBatchContext): Promise<void> {
-    const entities = ctx.getEntities<DeployedERC1167Proxies>(ENTITY_TYPE);
-    if (entities.size === 0) return;
-
-    await store.insert([...entities.values()]);
+    await insertEntities(store, ctx, ENTITY_TYPE);
   },
 };
 

--- a/packages/indexer-v2/src/plugins/events/follow.plugin.ts
+++ b/packages/indexer-v2/src/plugins/events/follow.plugin.ts
@@ -24,6 +24,7 @@ import { Follow, Follower, UniversalProfile } from '@chillwhales/typeorm';
 import { Store } from '@subsquid/typeorm-store';
 
 import { LSP26_ADDRESS } from '@/constants';
+import { insertEntities } from '@/core/pluginHelpers';
 import {
   Block,
   EntityCategory,
@@ -94,11 +95,7 @@ const FollowPlugin: EventPlugin = {
   // ---------------------------------------------------------------------------
 
   async persist(store: Store, ctx: IBatchContext): Promise<void> {
-    const entities = ctx.getEntities<Follow>(ENTITY_TYPE);
-    if (entities.size === 0) return;
-
-    // Raw event log — append-only with UUID ids
-    await store.insert([...entities.values()]);
+    await insertEntities(store, ctx, ENTITY_TYPE);
   },
 
   // ---------------------------------------------------------------------------

--- a/packages/indexer-v2/src/plugins/events/ownershipTransferred.plugin.ts
+++ b/packages/indexer-v2/src/plugins/events/ownershipTransferred.plugin.ts
@@ -19,14 +19,13 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { LSP14Ownable2Step } from '@chillwhales/abi';
 import {
-  DigitalAsset,
   DigitalAssetOwner,
   OwnershipTransferred,
-  UniversalProfile,
   UniversalProfileOwner,
 } from '@chillwhales/typeorm';
 import { Store } from '@subsquid/typeorm-store';
 
+import { insertEntities, populateByUPAndDA } from '@/core/pluginHelpers';
 import {
   Block,
   EntityCategory,
@@ -76,20 +75,7 @@ const OwnershipTransferredPlugin: EventPlugin = {
   // ---------------------------------------------------------------------------
 
   populate(ctx: IBatchContext): void {
-    const entities = ctx.getEntities<OwnershipTransferred>(ENTITY_TYPE);
-
-    for (const [id, entity] of entities) {
-      const isUP = ctx.isValid(EntityCategory.UniversalProfile, entity.address);
-      const isDA = ctx.isValid(EntityCategory.DigitalAsset, entity.address);
-
-      if (!isUP && !isDA) {
-        ctx.removeEntity(ENTITY_TYPE, id);
-        continue;
-      }
-
-      entity.universalProfile = isUP ? new UniversalProfile({ id: entity.address }) : null;
-      entity.digitalAsset = isDA ? new DigitalAsset({ id: entity.address }) : null;
-    }
+    populateByUPAndDA<OwnershipTransferred>(ctx, ENTITY_TYPE);
   },
 
   // ---------------------------------------------------------------------------
@@ -97,10 +83,7 @@ const OwnershipTransferredPlugin: EventPlugin = {
   // ---------------------------------------------------------------------------
 
   async persist(store: Store, ctx: IBatchContext): Promise<void> {
-    const entities = ctx.getEntities<OwnershipTransferred>(ENTITY_TYPE);
-    if (entities.size === 0) return;
-
-    await store.insert([...entities.values()]);
+    await insertEntities(store, ctx, ENTITY_TYPE);
   },
 
   // ---------------------------------------------------------------------------

--- a/packages/indexer-v2/src/plugins/events/unfollow.plugin.ts
+++ b/packages/indexer-v2/src/plugins/events/unfollow.plugin.ts
@@ -24,6 +24,7 @@ import { Follower, Unfollow, UniversalProfile } from '@chillwhales/typeorm';
 import { Store } from '@subsquid/typeorm-store';
 
 import { LSP26_ADDRESS } from '@/constants';
+import { insertEntities } from '@/core/pluginHelpers';
 import {
   Block,
   EntityCategory,
@@ -95,11 +96,7 @@ const UnfollowPlugin: EventPlugin = {
   // ---------------------------------------------------------------------------
 
   async persist(store: Store, ctx: IBatchContext): Promise<void> {
-    const entities = ctx.getEntities<Unfollow>(ENTITY_TYPE);
-    if (entities.size === 0) return;
-
-    // Raw event log — append-only with UUID ids
-    await store.insert([...entities.values()]);
+    await insertEntities(store, ctx, ENTITY_TYPE);
   },
 
   // ---------------------------------------------------------------------------

--- a/packages/indexer-v2/src/plugins/events/universalReceiver.plugin.ts
+++ b/packages/indexer-v2/src/plugins/events/universalReceiver.plugin.ts
@@ -15,9 +15,10 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import { LSP0ERC725Account } from '@chillwhales/abi';
-import { UniversalProfile, UniversalReceiver } from '@chillwhales/typeorm';
+import { UniversalReceiver } from '@chillwhales/typeorm';
 import { Store } from '@subsquid/typeorm-store';
 
+import { insertEntities, populateByUP } from '@/core/pluginHelpers';
 import { Block, EntityCategory, EventPlugin, IBatchContext, Log } from '@/core/types';
 
 // Entity type key used in the BatchContext entity bag
@@ -63,15 +64,7 @@ const UniversalReceiverPlugin: EventPlugin = {
   // ---------------------------------------------------------------------------
 
   populate(ctx: IBatchContext): void {
-    const entities = ctx.getEntities<UniversalReceiver>(ENTITY_TYPE);
-
-    for (const [id, entity] of entities) {
-      if (ctx.isValid(EntityCategory.UniversalProfile, entity.address)) {
-        entity.universalProfile = new UniversalProfile({ id: entity.address });
-      } else {
-        ctx.removeEntity(ENTITY_TYPE, id);
-      }
-    }
+    populateByUP<UniversalReceiver>(ctx, ENTITY_TYPE);
   },
 
   // ---------------------------------------------------------------------------
@@ -79,10 +72,7 @@ const UniversalReceiverPlugin: EventPlugin = {
   // ---------------------------------------------------------------------------
 
   async persist(store: Store, ctx: IBatchContext): Promise<void> {
-    const entities = ctx.getEntities<UniversalReceiver>(ENTITY_TYPE);
-    if (entities.size === 0) return;
-
-    await store.insert([...entities.values()]);
+    await insertEntities(store, ctx, ENTITY_TYPE);
   },
 };
 


### PR DESCRIPTION
## Summary
- Adds `dataChanged.plugin.ts` — the meta-plugin that handles all `DataChanged(bytes32,bytes)` events from ERC725Y contracts
- Creates `DataChanged` entities (UUID, append-only insert) for every event
- Tracks `log.address` as both UniversalProfile and DigitalAsset candidates (contract type unknown at scan time)
- Routes decoded `dataKey` to the matching `DataKeyPlugin` via `registry.getDataKeyPlugin(dataKey)` for sub-entity extraction
- Uses a factory function `createDataChangedPlugin(registry)` — the registry is captured in closure since the plugin needs it for dataKey routing
- Must be manually registered during startup (not auto-discovered): `registry.registerEventPlugin(createDataChangedPlugin(registry))`

### Design Notes
- This is the only "meta-plugin" in the system — all other event plugins are self-contained
- DataKeyPlugins handle their own populate/persist lifecycle — they're called by the pipeline via `registry.getActivePlugins()`
- The factory pattern avoids adding registry access to the `EventPlugin` interface, keeping the contract clean for all other plugins
- Completes Phase 2 (Event Plugins) — all 11 event plugins are now implemented

Closes #29