### PR TITLE
feat: LSP4 simple data key plugins (Name, Symbol, Type) (#31)

### DIFF
--- a/packages/indexer-v2/src/plugins/datakeys/lsp4TokenName.plugin.ts
+++ b/packages/indexer-v2/src/plugins/datakeys/lsp4TokenName.plugin.ts
@@ -1,0 +1,73 @@
+/**
+ * LSP4TokenName data key plugin.
+ *
+ * Handles the `LSP4TokenName` data key emitted via `DataChanged(bytes32,bytes)`
+ * on Digital Assets. Decodes the hex-encoded token name string.
+ *
+ * Port from v1:
+ *   - utils/dataChanged/lsp4TokenName.ts (extract + populate)
+ *   - app/index.ts L426 (upsert)
+ */
+import { LSP4DataKeys } from '@lukso/lsp4-contracts';
+
+import { LSP4TokenName } from '@chillwhales/typeorm';
+import { Store } from '@subsquid/typeorm-store';
+import { hexToString, isHex } from 'viem';
+
+import { populateByDA, upsertEntities } from '@/core/pluginHelpers';
+import { Block, DataKeyPlugin, EntityCategory, IBatchContext, Log } from '@/core/types';
+
+// Entity type key used in the BatchContext entity bag
+const ENTITY_TYPE = 'LSP4TokenName';
+
+const LSP4_TOKEN_NAME_KEY: string = LSP4DataKeys.LSP4TokenName;
+
+const LSP4TokenNamePlugin: DataKeyPlugin = {
+  name: 'lsp4TokenName',
+  requiresVerification: [EntityCategory.DigitalAsset],
+
+  // ---------------------------------------------------------------------------
+  // Matching
+  // ---------------------------------------------------------------------------
+
+  matches(dataKey: string): boolean {
+    return dataKey === LSP4_TOKEN_NAME_KEY;
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 1: EXTRACT
+  // ---------------------------------------------------------------------------
+
+  extract(log: Log, _dataKey: string, dataValue: string, block: Block, ctx: IBatchContext): void {
+    const { timestamp } = block.header;
+    const { address } = log;
+
+    const entity = new LSP4TokenName({
+      id: address,
+      address,
+      timestamp: new Date(timestamp),
+      value: !isHex(dataValue) || dataValue === '0x' ? null : hexToString(dataValue),
+      rawValue: dataValue,
+    });
+
+    ctx.addEntity(ENTITY_TYPE, entity.id, entity);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 3: POPULATE
+  // ---------------------------------------------------------------------------
+
+  populate(ctx: IBatchContext): void {
+    populateByDA<LSP4TokenName>(ctx, ENTITY_TYPE);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 4: PERSIST
+  // ---------------------------------------------------------------------------
+
+  async persist(store: Store, ctx: IBatchContext): Promise<void> {
+    await upsertEntities(store, ctx, ENTITY_TYPE);
+  },
+};
+
+export default LSP4TokenNamePlugin;

--- a/packages/indexer-v2/src/plugins/datakeys/lsp4TokenSymbol.plugin.ts
+++ b/packages/indexer-v2/src/plugins/datakeys/lsp4TokenSymbol.plugin.ts
@@ -1,0 +1,73 @@
+/**
+ * LSP4TokenSymbol data key plugin.
+ *
+ * Handles the `LSP4TokenSymbol` data key emitted via `DataChanged(bytes32,bytes)`
+ * on Digital Assets. Decodes the hex-encoded token symbol string.
+ *
+ * Port from v1:
+ *   - utils/dataChanged/lsp4TokenSymbol.ts (extract + populate)
+ *   - app/index.ts L427 (upsert)
+ */
+import { LSP4DataKeys } from '@lukso/lsp4-contracts';
+
+import { LSP4TokenSymbol } from '@chillwhales/typeorm';
+import { Store } from '@subsquid/typeorm-store';
+import { hexToString, isHex } from 'viem';
+
+import { populateByDA, upsertEntities } from '@/core/pluginHelpers';
+import { Block, DataKeyPlugin, EntityCategory, IBatchContext, Log } from '@/core/types';
+
+// Entity type key used in the BatchContext entity bag
+const ENTITY_TYPE = 'LSP4TokenSymbol';
+
+const LSP4_TOKEN_SYMBOL_KEY: string = LSP4DataKeys.LSP4TokenSymbol;
+
+const LSP4TokenSymbolPlugin: DataKeyPlugin = {
+  name: 'lsp4TokenSymbol',
+  requiresVerification: [EntityCategory.DigitalAsset],
+
+  // ---------------------------------------------------------------------------
+  // Matching
+  // ---------------------------------------------------------------------------
+
+  matches(dataKey: string): boolean {
+    return dataKey === LSP4_TOKEN_SYMBOL_KEY;
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 1: EXTRACT
+  // ---------------------------------------------------------------------------
+
+  extract(log: Log, _dataKey: string, dataValue: string, block: Block, ctx: IBatchContext): void {
+    const { timestamp } = block.header;
+    const { address } = log;
+
+    const entity = new LSP4TokenSymbol({
+      id: address,
+      address,
+      timestamp: new Date(timestamp),
+      value: !isHex(dataValue) || dataValue === '0x' ? null : hexToString(dataValue),
+      rawValue: dataValue,
+    });
+
+    ctx.addEntity(ENTITY_TYPE, entity.id, entity);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 3: POPULATE
+  // ---------------------------------------------------------------------------
+
+  populate(ctx: IBatchContext): void {
+    populateByDA<LSP4TokenSymbol>(ctx, ENTITY_TYPE);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 4: PERSIST
+  // ---------------------------------------------------------------------------
+
+  async persist(store: Store, ctx: IBatchContext): Promise<void> {
+    await upsertEntities(store, ctx, ENTITY_TYPE);
+  },
+};
+
+export default LSP4TokenSymbolPlugin;

--- a/packages/indexer-v2/src/plugins/datakeys/lsp4TokenType.plugin.ts
+++ b/packages/indexer-v2/src/plugins/datakeys/lsp4TokenType.plugin.ts
@@ -1,0 +1,76 @@
+/**
+ * LSP4TokenType data key plugin.
+ *
+ * Handles the `LSP4TokenType` data key emitted via `DataChanged(bytes32,bytes)`
+ * on Digital Assets. Decodes the hex-encoded token type enum value
+ * (0 = TOKEN, 1 = NFT, 2 = COLLECTION).
+ *
+ * Port from v1:
+ *   - utils/dataChanged/lsp4TokenType.ts (extract + populate)
+ *   - app/index.ts L428 (upsert)
+ */
+import { LSP4DataKeys } from '@lukso/lsp4-contracts';
+
+import { LSP4TokenType } from '@chillwhales/typeorm';
+import { Store } from '@subsquid/typeorm-store';
+import { hexToNumber, isHex } from 'viem';
+
+import { populateByDA, upsertEntities } from '@/core/pluginHelpers';
+import { Block, DataKeyPlugin, EntityCategory, IBatchContext, Log } from '@/core/types';
+import { decodeTokenType } from '@/utils';
+
+// Entity type key used in the BatchContext entity bag
+const ENTITY_TYPE = 'LSP4TokenType';
+
+const LSP4_TOKEN_TYPE_KEY: string = LSP4DataKeys.LSP4TokenType;
+
+const LSP4TokenTypePlugin: DataKeyPlugin = {
+  name: 'lsp4TokenType',
+  requiresVerification: [EntityCategory.DigitalAsset],
+
+  // ---------------------------------------------------------------------------
+  // Matching
+  // ---------------------------------------------------------------------------
+
+  matches(dataKey: string): boolean {
+    return dataKey === LSP4_TOKEN_TYPE_KEY;
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 1: EXTRACT
+  // ---------------------------------------------------------------------------
+
+  extract(log: Log, _dataKey: string, dataValue: string, block: Block, ctx: IBatchContext): void {
+    const { timestamp } = block.header;
+    const { address } = log;
+
+    const entity = new LSP4TokenType({
+      id: address,
+      address,
+      timestamp: new Date(timestamp),
+      value:
+        !isHex(dataValue) || dataValue === '0x' ? null : decodeTokenType(hexToNumber(dataValue)),
+      rawValue: dataValue,
+    });
+
+    ctx.addEntity(ENTITY_TYPE, entity.id, entity);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 3: POPULATE
+  // ---------------------------------------------------------------------------
+
+  populate(ctx: IBatchContext): void {
+    populateByDA<LSP4TokenType>(ctx, ENTITY_TYPE);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 4: PERSIST
+  // ---------------------------------------------------------------------------
+
+  async persist(store: Store, ctx: IBatchContext): Promise<void> {
+    await upsertEntities(store, ctx, ENTITY_TYPE);
+  },
+};
+
+export default LSP4TokenTypePlugin;

--- a/packages/indexer-v2/src/utils/index.ts
+++ b/packages/indexer-v2/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { OperationType } from '@chillwhales/typeorm';
+import { LSP4TokenTypeEnum, OperationType } from '@chillwhales/typeorm';
 import ERC725 from '@erc725/erc725.js';
 import { hexToNumber, isHex } from 'viem';
 
@@ -81,6 +81,23 @@ export function generateFollowId({
   followedAddress: string;
 }): string {
   return `${followerAddress} - ${followedAddress}`;
+}
+
+/**
+ * Map LSP4 token type integer to the LSP4TokenTypeEnum.
+ *
+ * 0 = TOKEN, 1 = NFT, 2 = COLLECTION.
+ *
+ * Port from v1: utils/index.ts decodeTokenType()
+ */
+export function decodeTokenType(tokenType: number): LSP4TokenTypeEnum | null {
+  return tokenType === 0
+    ? LSP4TokenTypeEnum.TOKEN
+    : tokenType === 1
+      ? LSP4TokenTypeEnum.NFT
+      : tokenType === 2
+        ? LSP4TokenTypeEnum.COLLECTION
+        : null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements three simple LSP4 data key plugins: `LSP4TokenName`, `LSP4TokenSymbol`, `LSP4TokenType`
- Adds `decodeTokenType()` utility to `utils/index.ts` (maps 0→TOKEN, 1→NFT, 2→COLLECTION)
- All three plugins follow the established DataKeyPlugin pattern: `matches()` → `extract()` → `populate()` → `persist()`

## Details

Each plugin:
- **matches**: exact key comparison against `LSP4DataKeys.LSP4TokenName` / `LSP4TokenSymbol` / `LSP4TokenType`
- **extract**: decodes `dataValue` — `hexToString` for Name/Symbol, `hexToNumber` + `decodeTokenType` for Type
- **populate**: uses `populateByDA()` helper (requires verified DigitalAsset)
- **persist**: uses `upsertEntities()` (deterministic id = contract address)
- No `clearSubEntities` needed (single-row entities, no sub-entities)
- No `handle()` needed (no metadata fetching)

## Files Changed
| File | Change |
|------|--------|
| `plugins/datakeys/lsp4TokenName.plugin.ts` | New — LSP4TokenName DataKeyPlugin |
| `plugins/datakeys/lsp4TokenSymbol.plugin.ts` | New — LSP4TokenSymbol DataKeyPlugin |
| `plugins/datakeys/lsp4TokenType.plugin.ts` | New — LSP4TokenType DataKeyPlugin |
| `utils/index.ts` | Added `decodeTokenType()` + `LSP4TokenTypeEnum` import |

## Build
`pnpm --filter=@chillwhales/indexer-v2 build` passes cleanly.

Closes #31