### PR TITLE
feat: LSP4Metadata data key plugin (#32)

### DIFF
--- a/packages/indexer-v2/src/plugins/datakeys/lsp4Metadata.plugin.ts
+++ b/packages/indexer-v2/src/plugins/datakeys/lsp4Metadata.plugin.ts
@@ -1,13 +1,15 @@
 /**
  * LSP4Metadata data key plugin.
  *
- * Handles the `LSP4Metadata` VerifiableURI data key emitted via
- * `DataChanged(bytes32,bytes)` on Digital Assets.
+ * Handles the `LSP4Metadata` VerifiableURI data key emitted via:
+ *   - `DataChanged(bytes32,bytes)` on Digital Assets (id = address)
+ *   - `TokenIdDataChanged(bytes32,bytes32,bytes)` on LSP8 contracts (id = "{address} - {tokenId}")
  *
  * When metadata is updated, this plugin:
  *   1. Decodes the VerifiableURI from the data value to get a metadata URL
- *   2. Creates/updates the `LSP4Metadata` entity (deterministic id = address)
- *   3. Clears existing sub-entities before re-inserting (delete-then-reinsert)
+ *   2. Creates/updates the `LSP4Metadata` entity with deterministic id
+ *   3. For TokenIdDataChanged: links entity to NFT via tokenId
+ *   4. Clears existing sub-entities before re-inserting (delete-then-reinsert)
  *
  * Sub-entity creation and metadata fetching are handled by the LSP4 metadata
  * fetch handler (Phase 5, issue #54). This plugin only persists the main
@@ -15,11 +17,13 @@
  *
  * Port from v1:
  *   - utils/dataChanged/lsp4Metadata.ts (extract + populate + clearSubEntities)
+ *   - utils/tokenIdDataChanged/lsp4Metadata.ts (extract with tokenId + nft)
  *   - app/index.ts L202-206, L423-424 (clear + upsert)
  */
 import { LSP4DataKeys } from '@lukso/lsp4-contracts';
 
 import {
+  DigitalAsset,
   LSP4Metadata,
   LSP4MetadataAsset,
   LSP4MetadataAttribute,
@@ -29,18 +33,37 @@ import {
   LSP4MetadataImage,
   LSP4MetadataLink,
   LSP4MetadataName,
+  NFT,
 } from '@chillwhales/typeorm';
 import { Store } from '@subsquid/typeorm-store';
 import { In } from 'typeorm';
 
-import { populateByDA, upsertEntities } from '@/core/pluginHelpers';
+import { upsertEntities } from '@/core/pluginHelpers';
 import { Block, DataKeyPlugin, EntityCategory, IBatchContext, Log } from '@/core/types';
-import { decodeVerifiableUri } from '@/utils';
+import { decodeVerifiableUri, generateTokenId } from '@/utils';
 
 // Entity type key used in the BatchContext entity bag
 const ENTITY_TYPE = 'LSP4Metadata';
 
 const LSP4_METADATA_KEY: string = LSP4DataKeys.LSP4Metadata;
+
+/**
+ * Detect whether the log originates from a TokenIdDataChanged event.
+ *
+ * DataChanged(bytes32 indexed dataKey, bytes dataValue) has 2 topics.
+ * TokenIdDataChanged(bytes32 indexed tokenId, bytes32 indexed dataKey, bytes dataValue) has 3 topics.
+ */
+function isTokenIdDataChanged(log: Log): boolean {
+  return log.topics.length === 3;
+}
+
+/**
+ * Extract tokenId from a TokenIdDataChanged log.
+ * The tokenId is the first indexed parameter (topics[1]).
+ */
+function extractTokenId(log: Log): string {
+  return log.topics[1];
+}
 
 const LSP4MetadataPlugin: DataKeyPlugin = {
   name: 'lsp4Metadata',
@@ -63,20 +86,40 @@ const LSP4MetadataPlugin: DataKeyPlugin = {
     const { address } = log;
     const { value: url, decodeError } = decodeVerifiableUri(dataValue);
 
-    // Deterministic id = contract address (later events overwrite earlier ones
-    // in the same batch, matching v1 Map<string, LSP4Metadata> behavior)
-    const entity = new LSP4Metadata({
-      id: address,
-      address,
-      timestamp: new Date(timestamp),
-      url,
-      rawValue: dataValue,
-      decodeError,
-      isDataFetched: false,
-      retryCount: 0,
-    });
+    if (isTokenIdDataChanged(log)) {
+      // TokenIdDataChanged path: id = "{address} - {tokenId}", linked to NFT
+      const tokenId = extractTokenId(log);
+      const nftId = generateTokenId({ address, tokenId });
 
-    ctx.addEntity(ENTITY_TYPE, entity.id, entity);
+      const entity = new LSP4Metadata({
+        id: nftId,
+        address,
+        timestamp: new Date(timestamp),
+        tokenId,
+        nft: new NFT({ id: nftId, tokenId, address }),
+        url,
+        rawValue: dataValue,
+        decodeError,
+        isDataFetched: false,
+        retryCount: 0,
+      });
+
+      ctx.addEntity(ENTITY_TYPE, entity.id, entity);
+    } else {
+      // DataChanged path: id = address (no tokenId, no NFT)
+      const entity = new LSP4Metadata({
+        id: address,
+        address,
+        timestamp: new Date(timestamp),
+        url,
+        rawValue: dataValue,
+        decodeError,
+        isDataFetched: false,
+        retryCount: 0,
+      });
+
+      ctx.addEntity(ENTITY_TYPE, entity.id, entity);
+    }
   },
 
   // ---------------------------------------------------------------------------
@@ -84,7 +127,23 @@ const LSP4MetadataPlugin: DataKeyPlugin = {
   // ---------------------------------------------------------------------------
 
   populate(ctx: IBatchContext): void {
-    populateByDA<LSP4Metadata>(ctx, ENTITY_TYPE);
+    const entities = ctx.getEntities<LSP4Metadata>(ENTITY_TYPE);
+
+    for (const [id, entity] of entities) {
+      if (ctx.isValid(EntityCategory.DigitalAsset, entity.address)) {
+        entity.digitalAsset = new DigitalAsset({ id: entity.address });
+
+        // For TokenIdDataChanged-sourced entities: enrich nft.digitalAsset
+        if (entity.nft) {
+          entity.nft = new NFT({
+            ...entity.nft,
+            digitalAsset: new DigitalAsset({ id: entity.address }),
+          });
+        }
+      } else {
+        ctx.removeEntity(ENTITY_TYPE, id);
+      }
+    }
   },
 
   // ---------------------------------------------------------------------------
@@ -131,7 +190,7 @@ const LSP4MetadataPlugin: DataKeyPlugin = {
   // ---------------------------------------------------------------------------
 
   async persist(store: Store, ctx: IBatchContext): Promise<void> {
-    // Upsert main LSP4Metadata (deterministic id = address, may already exist)
+    // Upsert main LSP4Metadata (deterministic id, may already exist)
     await upsertEntities(store, ctx, ENTITY_TYPE);
   },
 };


### PR DESCRIPTION
## Summary
- Implements the `LSP4Metadata` data key plugin handling VerifiableURI metadata on Digital Assets and NFTs
- Handles both `DataChanged` (id=address) and `TokenIdDataChanged` (id="{address} - {tokenId}") event sources
- Includes `clearSubEntities()` for delete-then-reinsert of 8 sub-entity types
- Converts `TokenIdDataChanged` plugin to factory function for data key routing via registry
- Metadata fetching deferred to Phase 5 handler (#54)

## Details

### LSP4Metadata Plugin
| Method | Behavior |
|--------|----------|
| `matches` | Exact key match against `LSP4DataKeys.LSP4Metadata` |
| `extract` | Detects event source via `log.topics.length` (2=DataChanged, 3=TokenIdDataChanged). Decodes VerifiableURI → URL. For TokenIdDataChanged: sets `tokenId` + `nft` link, id = `"{address} - {tokenId}"`. For DataChanged: id = address |
| `populate` | Links to verified DigitalAsset. For NFT-linked entities: also enriches `nft.digitalAsset` |
| `clearSubEntities` | Deletes existing sub-entities for 8 types: Asset, Attribute, Category, Description, Icon, Image, Link, Name |
| `persist` | `upsertEntities()` — upserts main LSP4Metadata entity |

### TokenIdDataChanged Plugin (Breaking Change)
- Converted from plain object to **factory function** `createTokenIdDataChangedPlugin(registry)` — same pattern as `createDataChangedPlugin(registry)`
- Now routes decoded `dataKey` to matching `DataKeyPlugin` via registry (currently: LSP4Metadata per tokenId)
- Must be **manually registered** at startup (no longer auto-discovered since it exports a function, not an object)

## Files Changed
| File | Change |
|------|--------|
| `plugins/datakeys/lsp4Metadata.plugin.ts` | New — LSP4Metadata DataKeyPlugin with dual-source extract + clearSubEntities |
| `plugins/events/tokenIdDataChanged.plugin.ts` | **Modified** — converted to factory, added data key routing |

## Build
`pnpm --filter=@chillwhales/indexer-v2 build` passes cleanly.

Closes #32