### PR TITLE
feat(indexer-v2): ChillWhales OrbLevel + OrbFaction data key plugins (#39)

### DIFF
--- a/packages/indexer-v2/src/plugins/datakeys/chillwhales/orbFaction.plugin.ts
+++ b/packages/indexer-v2/src/plugins/datakeys/chillwhales/orbFaction.plugin.ts
@@ -1,0 +1,98 @@
+/**
+ * OrbFaction data key plugin (ChillWhales-specific).
+ *
+ * Handles the `ORB_FACTION_KEY` data key emitted via
+ * `TokenIdDataChanged(bytes32,bytes32,bytes)` on the ORBS contract.
+ *
+ * The data value contains a UTF-8 encoded faction name string
+ * (e.g. "Neutral", "Fire", "Water", etc.).
+ *
+ * Produces a single entity type:
+ *   - `OrbFaction` — current faction of the orb NFT
+ *
+ * Scoped to the ORBS contract address. Events from other contracts
+ * matching the same data key hash are ignored.
+ *
+ * Entity ID follows the NFT id pattern: `"{address} - {tokenId}"`.
+ *
+ * Port from v1:
+ *   - app/handlers/orbsLevelHandler.ts (OrbFaction from TokenIdDataChanged)
+ *   - constants/chillwhales.ts (ORB_FACTION_KEY, ORBS_ADDRESS)
+ */
+import { DigitalAsset, NFT, OrbFaction } from '@chillwhales/typeorm';
+import { Store } from '@subsquid/typeorm-store';
+import { Hex, hexToString } from 'viem';
+
+import { ORB_FACTION_KEY, ORBS_ADDRESS } from '@/constants/chillwhales';
+import { populateByDA, upsertEntities } from '@/core/pluginHelpers';
+import { Block, DataKeyPlugin, EntityCategory, IBatchContext, Log } from '@/core/types';
+import { generateTokenId } from '@/utils';
+
+// ---------------------------------------------------------------------------
+// Entity type key used in the BatchContext entity bag
+// ---------------------------------------------------------------------------
+const ORB_FACTION_TYPE = 'OrbFaction';
+
+const OrbFactionPlugin: DataKeyPlugin = {
+  name: 'orbFaction',
+  requiresVerification: [EntityCategory.DigitalAsset],
+
+  // ---------------------------------------------------------------------------
+  // Matching
+  // ---------------------------------------------------------------------------
+
+  matches(dataKey: string): boolean {
+    return dataKey === ORB_FACTION_KEY;
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 1: EXTRACT
+  // ---------------------------------------------------------------------------
+
+  extract(log: Log, _dataKey: string, dataValue: string, block: Block, ctx: IBatchContext): void {
+    const { address } = log;
+
+    // Only process events from the ORBS contract
+    if (address.toLowerCase() !== ORBS_ADDRESS.toLowerCase()) return;
+
+    // Only process TokenIdDataChanged events (3 topics)
+    if (log.topics.length !== 3) return;
+
+    const tokenId = log.topics[1];
+    const id = generateTokenId({ address, tokenId });
+    const faction = hexToString(dataValue as Hex);
+
+    ctx.addEntity(
+      ORB_FACTION_TYPE,
+      id,
+      new OrbFaction({
+        id,
+        address,
+        digitalAsset: new DigitalAsset({ id: address }),
+        tokenId,
+        nft: new NFT({ id, tokenId, address }),
+        value: faction,
+      }),
+    );
+
+    // Address tracking is handled by the TokenIdDataChanged meta-plugin (parent).
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 3: POPULATE
+  // ---------------------------------------------------------------------------
+
+  populate(ctx: IBatchContext): void {
+    populateByDA<OrbFaction>(ctx, ORB_FACTION_TYPE);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 4: PERSIST
+  // ---------------------------------------------------------------------------
+
+  async persist(store: Store, ctx: IBatchContext): Promise<void> {
+    await upsertEntities(store, ctx, ORB_FACTION_TYPE);
+  },
+};
+
+export default OrbFactionPlugin;

--- a/packages/indexer-v2/src/plugins/datakeys/chillwhales/orbLevel.plugin.ts
+++ b/packages/indexer-v2/src/plugins/datakeys/chillwhales/orbLevel.plugin.ts
@@ -1,0 +1,119 @@
+/**
+ * OrbLevel data key plugin (ChillWhales-specific).
+ *
+ * Handles the `ORB_LEVEL_KEY` data key emitted via
+ * `TokenIdDataChanged(bytes32,bytes32,bytes)` on the ORBS contract.
+ *
+ * The data value packs two uint32 values:
+ *   - **bytes 0–3**: orb level (uint32)
+ *   - **bytes 4–7**: cooldown expiry timestamp (uint32)
+ *
+ * Produces two entity types from a single data key:
+ *   - `OrbLevel`          — current level of the orb NFT
+ *   - `OrbCooldownExpiry` — cooldown expiry timestamp after level-up
+ *
+ * Both entities are scoped to the ORBS contract address. Events from
+ * other contracts matching the same data key hash are ignored.
+ *
+ * Entity IDs follow the NFT id pattern: `"{address} - {tokenId}"`.
+ *
+ * Port from v1:
+ *   - app/handlers/orbsLevelHandler.ts (OrbLevel + OrbCooldownExpiry from TokenIdDataChanged)
+ *   - constants/chillwhales.ts (ORB_LEVEL_KEY, ORBS_ADDRESS)
+ */
+import { DigitalAsset, NFT, OrbCooldownExpiry, OrbLevel } from '@chillwhales/typeorm';
+import { Store } from '@subsquid/typeorm-store';
+import { bytesToNumber, Hex, hexToBytes, isHex, sliceBytes } from 'viem';
+
+import { ORB_LEVEL_KEY, ORBS_ADDRESS } from '@/constants/chillwhales';
+import { populateByDA, upsertEntities } from '@/core/pluginHelpers';
+import { Block, DataKeyPlugin, EntityCategory, IBatchContext, Log } from '@/core/types';
+import { generateTokenId } from '@/utils';
+
+// ---------------------------------------------------------------------------
+// Entity type keys used in the BatchContext entity bag
+// ---------------------------------------------------------------------------
+const ORB_LEVEL_TYPE = 'OrbLevel';
+const ORB_COOLDOWN_EXPIRY_TYPE = 'OrbCooldownExpiry';
+
+const OrbLevelPlugin: DataKeyPlugin = {
+  name: 'orbLevel',
+  requiresVerification: [EntityCategory.DigitalAsset],
+
+  // ---------------------------------------------------------------------------
+  // Matching
+  // ---------------------------------------------------------------------------
+
+  matches(dataKey: string): boolean {
+    return dataKey === ORB_LEVEL_KEY;
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 1: EXTRACT
+  // ---------------------------------------------------------------------------
+
+  extract(log: Log, _dataKey: string, dataValue: string, block: Block, ctx: IBatchContext): void {
+    const { address } = log;
+
+    // Only process events from the ORBS contract
+    if (address.toLowerCase() !== ORBS_ADDRESS.toLowerCase()) return;
+
+    // Only process TokenIdDataChanged events (3 topics)
+    if (log.topics.length !== 3) return;
+
+    const tokenId = log.topics[1];
+    const id = generateTokenId({ address, tokenId });
+    const da = new DigitalAsset({ id: address });
+    const nft = new NFT({ id, tokenId, address });
+
+    // Decode packed data value: [level(uint32), cooldownExpiry(uint32)]
+    if (isHex(dataValue) && hexToBytes(dataValue as Hex).length >= 8) {
+      const dataBytes = hexToBytes(dataValue as Hex);
+      const level = bytesToNumber(sliceBytes(dataBytes, 0, 4));
+      const cooldownExpiry = bytesToNumber(sliceBytes(dataBytes, 4));
+
+      ctx.addEntity(
+        ORB_LEVEL_TYPE,
+        id,
+        new OrbLevel({ id, address, digitalAsset: da, tokenId, nft, value: level }),
+      );
+
+      ctx.addEntity(
+        ORB_COOLDOWN_EXPIRY_TYPE,
+        id,
+        new OrbCooldownExpiry({
+          id,
+          address,
+          digitalAsset: da,
+          tokenId,
+          nft,
+          value: cooldownExpiry,
+        }),
+      );
+    }
+
+    // Address tracking is handled by the TokenIdDataChanged meta-plugin (parent).
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 3: POPULATE
+  // ---------------------------------------------------------------------------
+
+  populate(ctx: IBatchContext): void {
+    populateByDA<OrbLevel>(ctx, ORB_LEVEL_TYPE);
+    populateByDA<OrbCooldownExpiry>(ctx, ORB_COOLDOWN_EXPIRY_TYPE);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Phase 4: PERSIST
+  // ---------------------------------------------------------------------------
+
+  async persist(store: Store, ctx: IBatchContext): Promise<void> {
+    await Promise.all([
+      upsertEntities(store, ctx, ORB_LEVEL_TYPE),
+      upsertEntities(store, ctx, ORB_COOLDOWN_EXPIRY_TYPE),
+    ]);
+  },
+};
+
+export default OrbLevelPlugin;


### PR DESCRIPTION
## Summary
- Implements two ChillWhales-specific DataKeyPlugins: `orbLevel` and `orbFaction`
- Both are contract-scoped to the ORBS contract address and only handle `TokenIdDataChanged` events
- ChillClaimed/OrbsClaimed handler logic deferred to Phase 5 (requires Multicall3 on-chain calls at chain head + Transfer event reactions)

## Details

### orbLevel.plugin.ts
Handles `ORB_LEVEL_KEY` — extracts **two** entity types from a single packed data value:
- **`OrbLevel`** — uint32 from bytes 0–3 (current orb level)
- **`OrbCooldownExpiry`** — uint32 from bytes 4–7 (cooldown expiry timestamp)

Both entities keyed by `"{address} - {tokenId}"`, linked to `DigitalAsset` and `NFT` FKs. Uses `populateByDA` + `upsertEntities`.

### orbFaction.plugin.ts
Handles `ORB_FACTION_KEY` — extracts a single entity type:
- **`OrbFaction`** — UTF-8 string decoded via `hexToString` (e.g. "Neutral", "Fire", "Water")

Same ID format and FK pattern as OrbLevel.

### Contract scoping
Both plugins check `log.address` against `ORBS_ADDRESS` and `log.topics.length === 3` (TokenIdDataChanged) in `extract()`. Events from other contracts with the same data key hashes are silently ignored.

### What's deferred to Phase 5
- **ChillClaimed**: Insert `value: false` on ChillWhale mint, then Multicall3 `getClaimedStatusFor` at chain head
- **OrbsClaimed**: Insert `value: false` on ChillWhale mint, then Multicall3 `getChillwhaleClaimStatus` at chain head
- **OrbLevel/OrbFaction default values on ORB mint**: Create `OrbLevel(0)`, `OrbCooldownExpiry(0)`, `OrbFaction("Neutral")` when an ORB is minted (Transfer handler logic)

Closes #39