### PR TITLE
fix(indexer-v2): preserve FK fields when reconstructing OwnedAsset/OwnedToken entities

### DIFF
--- a/packages/indexer-v2/src/handlers/ownedAssets.handler.ts
+++ b/packages/indexer-v2/src/handlers/ownedAssets.handler.ts
@@ -112,6 +112,9 @@ const OwnedAssetsHandler: EntityHandler = {
               block: blockNumber,
               timestamp,
               balance: newBalance,
+              // Explicitly preserve FK fields for enrichment
+              digitalAsset: existing.digitalAsset ?? null,
+              universalProfile: existing.universalProfile ?? null,
             }),
           );
         }
@@ -133,6 +136,9 @@ const OwnedAssetsHandler: EntityHandler = {
               block: blockNumber,
               timestamp,
               balance: existing.balance + amount,
+              // Explicitly preserve FK fields for enrichment
+              digitalAsset: existing.digitalAsset ?? null,
+              universalProfile: existing.universalProfile ?? null,
             }),
           );
         } else {
@@ -171,6 +177,11 @@ const OwnedAssetsHandler: EntityHandler = {
               block: blockNumber,
               timestamp,
               tokenId: null as unknown as string,
+              // Explicitly preserve FK fields for enrichment
+              digitalAsset: existing.digitalAsset ?? null,
+              universalProfile: existing.universalProfile ?? null,
+              nft: existing.nft ?? null,
+              ownedAsset: existing.ownedAsset ?? null,
             }),
           );
         }
@@ -193,6 +204,11 @@ const OwnedAssetsHandler: EntityHandler = {
               block: blockNumber,
               timestamp,
               tokenId,
+              // Explicitly preserve FK fields for enrichment
+              digitalAsset: existing.digitalAsset ?? null,
+              universalProfile: existing.universalProfile ?? null,
+              nft: existing.nft ?? null,
+              ownedAsset: existing.ownedAsset ?? null,
             }),
           );
         } else {


### PR DESCRIPTION
## Summary

- Explicitly preserve FK fields (`digitalAsset`, `universalProfile`, `nft`, `ownedAsset`) when reconstructing `OwnedAsset` and `OwnedToken` entities from database
- Fixes "FK field not found" warnings during ENRICH step

## Problem

During the ENRICH step (Step 6 of pipeline), numerous warnings appeared:

```
WARN sqd:processor:mapping Skipping enrichment: FK field not found on entity
  entityType: OwnedAsset
  entityId: 0x135ef4b91f16d22dd591c3cedc34b02f02988827:0x86e817172b5c07f7036743a83
  fkField: digitalAsset
```

**Root cause**: When entities are loaded from database and reconstructed using spread operator, FK fields that are `null`/`undefined` may not exist as own properties on the new instance, causing enrichment to fail.

## Changes

Modified `handlers/ownedAssets.handler.ts` at 4 reconstruction sites:

1. **OwnedAsset sender decrement** (lines 115-117)
2. **OwnedAsset receiver increment** (lines 139-141)  
3. **OwnedToken sender deletion** (lines 180-184)
4. **OwnedToken receiver restoration** (lines 207-211)

Each now explicitly preserves FK fields:

```typescript
new OwnedAsset({
  ...existing,
  block: blockNumber,
  timestamp,
  balance: newBalance,
  // Explicitly preserve FK fields for enrichment
  digitalAsset: existing.digitalAsset ?? null,
  universalProfile: existing.universalProfile ?? null,
})
```

## Testing

- Code compiles successfully
- Follows existing code style and patterns
- No runtime tests (tracked in #59)

## Related

- Fixes #141
- Epic: #11 (Indexer V2)
- Related: #140 (TypeORM mixed entity class bug)