### PR TITLE
test(indexer-v2): add comprehensive unit tests for OwnedAssets handler

### DIFF
--- a/packages/indexer-v2/src/handlers/__tests__/ownedAssets.handler.test.ts
+++ b/packages/indexer-v2/src/handlers/__tests__/ownedAssets.handler.test.ts
@@ -66,7 +66,6 @@ function createMockBatchCtx() {
 // ---------------------------------------------------------------------------
 // Mock Store helper
 // ---------------------------------------------------------------------------
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function createMockStore(
   existingOwnedAssets: OwnedAsset[] = [],
   existingOwnedTokens: OwnedToken[] = [],
@@ -257,10 +256,10 @@ describe('OwnedAssetsHandler', () => {
       await OwnedAssetsHandler.handle(hctx, 'LSP7Transfer');
 
       // Sender's OwnedAsset should be queued for deletion
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       expect(batchCtx.queueDelete).toHaveBeenCalledWith(
         expect.objectContaining({
           entityClass: OwnedAsset,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           entities: expect.arrayContaining([
             expect.objectContaining({
               id: existingSenderAsset.id,
@@ -437,10 +436,10 @@ describe('OwnedAssetsHandler', () => {
       await OwnedAssetsHandler.handle(hctx, 'LSP8Transfer');
 
       // Sender's OwnedToken should be queued for deletion
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       expect(batchCtx.queueDelete).toHaveBeenCalledWith(
         expect.objectContaining({
           entityClass: OwnedToken,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           entities: expect.arrayContaining([
             expect.objectContaining({
               id: existingToken.id,


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for the OwnedAssets handler to prevent regression of issue #141 (FK field preservation bug).

This PR addresses the [Copilot review comment on PR #142](https://github.com/chillwhales/lsp-indexer/pull/142#discussion_r2789598298):

> There's currently no unit test coverage for OwnedAssetsHandler (no handler test file found), so this behavior could easily break again without detection. Consider adding a focused test that loads an existing OwnedAsset/OwnedToken where FK properties are missing from the instance [...] and asserts the resulting entities have the FK keys present (even if null).

## Test Coverage

✅ **LSP7 Transfer Scenarios:**
- Create new OwnedAsset for first-time receiver
- Update existing OwnedAsset balance on transfer
- Queue deletion when balance reaches zero
- Queue enrichment for digitalAsset and universalProfile FKs
- **Critical**: Preserve FK fields during entity reconstruction (regression test for #141)

✅ **LSP8 Transfer Scenarios:**
- Create new OwnedToken for receiver
- Queue deletion when token is transferred away
- Preserve all FK fields (digitalAsset, universalProfile, nft, ownedAsset)
- Set ownedAsset FK directly when parent OwnedAsset exists

✅ **Dual-Trigger Accumulation:**
- Process both LSP7 and LSP8 transfers in same batch

## Key Regression Test

The most critical test simulates the exact bug from #141:

```typescript
it('preserves FK fields during entity reconstruction (regression test for #141)', async () => {
  const existingAsset = new OwnedAsset({ /* ... */ });
  
  // Simulate TypeORM behavior: delete FK properties to test preservation
  delete (existingAsset as any).digitalAsset;
  delete (existingAsset as any).universalProfile;
  
  // ... run handler ...
  
  // Critical assertion: FK fields must exist on reconstructed entity
  expect(reconstructed).toHaveProperty('digitalAsset');
  expect(reconstructed).toHaveProperty('universalProfile');
  expect(reconstructed.digitalAsset).toBe(null);
  expect(reconstructed.universalProfile).toBe(null);
});
```

This test will **fail immediately** if the explicit FK preservation from PR #142 is ever removed, preventing regression.

## Testing

Run tests:
```bash
pnpm --filter=@chillwhales/indexer-v2 test ownedAssets.handler.test.ts
```

## Related

- Addresses review comment: https://github.com/chillwhales/lsp-indexer/pull/142#discussion_r2789598298
- Tests fix from: #142
- Prevents regression of: #141
- Epic: #11