### PR TITLE
fix(indexer-v2): load .env from monorepo root

### DIFF
--- a/packages/indexer-v2/src/constants/index.ts
+++ b/packages/indexer-v2/src/constants/index.ts
@@ -2,9 +2,9 @@ import { isNumeric } from '@/utils';
 import { config as dotenvSetup } from 'dotenv';
 import path from 'path';
 
-// Load .env from monorepo root (two levels up from this file's location)
+// Load .env from monorepo root
 // This ensures env vars are loaded whether running from root or package directory
-dotenvSetup({ path: path.resolve(__dirname, '../../../.env') });
+dotenvSetup({ path: path.resolve(__dirname, '../../../../.env') });
 
 export const SQD_GATEWAY =
   process.env.SQD_GATEWAY || 'https://v2.archive.subsquid.io/network/lukso-mainnet';


### PR DESCRIPTION
## Summary

Fixes environment variable loading when running the indexer from the monorepo root.

## Problem

When running `pnpm --filter=./packages/indexer-v2 start` from the monorepo root, dotenv shows:
```
[dotenv@17.2.1] injecting env (0) from .env
```

This means **NO** environment variables were being loaded, causing the indexer to fall back to defaults for all configurations (DB_URL, RPC_URL, etc.).

## Root Cause

`dotenv.config()` looks for `.env` in the current working directory by default. When the compiled code runs, it can't find the `.env` file at the monorepo root.

## Solution

Configure dotenv to explicitly resolve the path to the monorepo root:

```typescript
import path from 'path';

// Load .env from monorepo root (two levels up from this file's location)
// This ensures env vars are loaded whether running from root or package directory
dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
```

**Path resolution:**
- Compiled code location: `/packages/indexer-v2/lib/constants/index.js`
- `__dirname` = `/packages/indexer-v2/lib/constants`
- `../../../` = monorepo root
- `../../../.env` = `/path/to/project/.env` ✅

## Testing

After this fix, running from monorepo root should show:
```
[dotenv@17.2.1] injecting env (X) from .env  // X > 0
```

And the indexer will use your actual configured values instead of defaults.

## Changes

- **`packages/indexer-v2/src/constants/index.ts`**
  - Import `path` module
  - Configure dotenv with explicit path to monorepo root `.env`
  - Add comment explaining the path resolution

## Related

- Follow-up to PR #144 (dual logging feature)
- Addresses issue discovered during testing