### PR TITLE
fix(indexer-v2): Limit batch size to prevent mid-sync failures

### DIFF
--- a/packages/indexer-v2/src/app/processor.ts
+++ b/packages/indexer-v2/src/app/processor.ts
@@ -16,6 +16,7 @@ export const processor = new EvmBatchProcessor()
   })
   .setFinalityConfirmation(FINALITY_CONFIRMATION)
   .setBlockRange({ from: 0 })
+  .setMaxBatchSize(10000) // Limit batch size to prevent OOM during large syncs
   .setFields({
     log: {
       address: true,


### PR DESCRIPTION
## Problem

The indexer-v2 deployment on Dokploy is stopping mid-sync at block **6,729,432** and never completing the full archive sync to 6,908,305+.

**Evidence from production logs:**
- Indexer processes blocks 0 → 6,729,432 successfully
- Starts final batch: `6729433-6908305` (179,873 blocks)
- Process stops during this batch without error
- Database shows `height: 6729432` (never committed the final batch)
- Current blockchain height: **6,921,659** (192k blocks behind)

**Root cause:** The final batch is too large (179k blocks), likely causing:
- Memory pressure leading to OOM kills
- Long processing time triggering timeouts
- Database transaction size issues

## Solution

Add `setMaxBatchSize(10000)` to the Subsquid processor configuration to limit batch sizes during sync.

### Benefits:
1. **Smaller memory footprint** - processes 10k blocks at a time instead of 179k
2. **More frequent commits** - progress is saved every 10k blocks
3. **Better resilience** - if process restarts, less work is lost
4. **Consistent performance** - batch processing time is predictable

### Changes:
- `packages/indexer-v2/src/app/processor.ts`: Add `.setMaxBatchSize(10000)`

## Testing

After this PR is merged and deployed:

1. **Monitor indexer progress:**
   ```bash
   docker logs -f lsp-indexer-v2 | grep "blocks/sec"
   ```

2. **Check database height:**
   ```graphql
   query {
     squid_processor_status {
       height
     }
   }
   ```

3. **Expected behavior:**
   - Resumes from block 6,729,432
   - Processes in 10k block batches
   - Reaches 6,908,305 (archive head)
   - **Switches to RPC mode for real-time sync** (from PR #149)
   - Continues running indefinitely ✅

## Related

Builds on #149 which fixed the RPC endpoint configuration. That PR enables continuous operation, this PR ensures we can complete the initial sync without stopping.

---

**Current Status:**
- Archive head: 6,908,305
- Indexer height: 6,729,432
- Blockchain head: 6,921,659
- Gap to close: **192,227 blocks**

With 10k batch size and ~270 blocks/sec mapping rate, should catch up in ~12 minutes.