### PR TITLE
docs(planning): Phase 5.3 research - Entity Upsert Pattern Standardization

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -330,7 +330,7 @@ Plans:
 3. User can verify ChillClaimed/OrbsClaimed retain FK references after Phase 2 verification (bug fix)
 4. User can verify lsp5ReceivedAssets correctly persists cross-batch merge data (bug fix)
 5. User can verify OrbLevel/OrbFaction preserve FKs across batch boundaries (gap fix)
-6. All existing tests pass — behavior unchanged, only implementation unified
+6. All existing tests pass, and runtime behavior matches intended V1 semantics (no regressions introduced by the unification work)
 
 **Plans:** 0 plans (run `/gsd-plan-phase 5.3` to break down)
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -147,7 +147,7 @@ _None currently._
 
 - **Date:** 2026-02-13
 - **Activity:** Handler audit for entity upsert pattern standardization
-- **Outcome:** Audited all 29 handlers, classified each by entity lifecycle pattern. Found 3 confirmed bugs (chillClaimed/orbsClaimed FK wipe in Phase 2, lsp5ReceivedAssets missing addEntity on DB merge) and 2 cross-batch FK gaps (orbLevel/orbFaction). Created Phase 5.3 with 3 requirements (UPSRT-01–03). Research complete, ready for planning.
+- **Outcome:** Audited all 29 handlers, classified each by entity lifecycle pattern. Found 3 confirmed bugs (chillClaimed/orbsClaimed FK wipe in Phase 2, lsp5ReceivedAssets missing addEntity on DB merge) and 2 cross-batch FK gaps (orbLevel/orbFaction). Created Phase 5.3 with 4 requirements (UPSRT-01–04). Research complete, ready for planning.
 - **Stopped at:** 05.3-RESEARCH.md complete, awaiting `/gsd-plan-phase 5.3`
 - **Resume file:** `.planning/phases/05.3-entity-upsert-pattern-standardization/05.3-RESEARCH.md`
 

--- a/.planning/phases/05.3-entity-upsert-pattern-standardization/05.3-RESEARCH.md
+++ b/.planning/phases/05.3-entity-upsert-pattern-standardization/05.3-RESEARCH.md
@@ -51,7 +51,7 @@ async function resolveEntities<T extends Entity>(
 ): Promise<Map<string, T>>;
 ```
 
-These replace `mergeEntitiesFromBatchAndDb` with a cleaner name and identical semantics. The old function is deleted; all call sites migrate to `resolveEntities`.
+`resolveEntities` replaces `mergeEntitiesFromBatchAndDb` with a clearer name and identical semantics. `resolveEntity` is a new single-entity variant for handlers that only need one lookup. The old function is deleted; all call sites migrate to the new helpers.
 
 ### The Canonical Code Shape
 
@@ -263,18 +263,12 @@ export async function resolveEntities<T extends Entity>(
   entityClass: EntityConstructor<T>,
   ids: string[],
 ): Promise<Map<string, T>> {
-  // 1. Get all from batch
+  // 1. Start with ALL batch entities (preserves intra-batch updates to other entities)
   const batchEntities = batchCtx.getEntities<T>(entityType);
-  const merged = new Map<string, T>();
+  const merged = new Map<string, T>(batchEntities);
 
-  // Add batch entities for requested IDs
-  for (const id of ids) {
-    const batchEntity = batchEntities.get(id);
-    if (batchEntity) merged.set(id, batchEntity);
-  }
-
-  // 2. Query DB for IDs not in batch
-  const idsNotInBatch = ids.filter((id) => !merged.has(id));
+  // 2. Query DB for requested IDs not already in batch
+  const idsNotInBatch = ids.filter((id) => !batchEntities.has(id));
   if (idsNotInBatch.length > 0) {
     const dbEntities = await store.findBy(entityClass, {
       id: In(idsNotInBatch),
@@ -313,110 +307,22 @@ const entity = new OrbLevel({
 // Result: digitalAsset and nft are PRESERVED from existing
 ```
 
-**For create case (existing is null):**
+**Handling the spread with nullable existing:**
 
-```typescript
-const existing = await resolveEntity(...);
+**Runtime behavior:** JavaScript/TypeScript ES2018+ allows `{...null}` and `{...undefined}`, both evaluate to `{}` (empty object). This means `...existing` when `existing` is `null` produces an empty object — no special handling needed at runtime.
 
-// When existing is null, spread is a no-op:
-const entity = new OrbLevel({
-  ...existing,        // ...null → no-op (Object spread of null/undefined is empty)
-  id,
-  address,
-  tokenId,
-  value: 0,
-  digitalAsset: null,
-  nft: null,
-});
-```
+**Type-checking behavior:** With `strictNullChecks` enabled (which this repo uses), TypeScript will flag `...existing` where `existing: T | null` because you cannot spread a possibly-null value without a type assertion or guard.
 
-Wait — `...null` doesn't work in TypeScript. We need to handle the null case. Two options:
-
-**Option A: Conditional spread**
-
-```typescript
-const entity = new OrbLevel({
-  ...(existing ?? {}),
-  id,
-  value: newValue,
-  // ... other fields for create case
-});
-```
-
-**Option B: Ternary**
-
-```typescript
-const entity = existing
-  ? new OrbLevel({ ...existing, value: newValue })
-  : new OrbLevel({ id, address, tokenId, value: newValue, digitalAsset: null, nft: null });
-```
-
-**Recommendation: Option A** — single code path, less branching, still recognizable. `...(existing ?? {})` is a clear "spread if exists, empty if not" idiom.
-
-Actually, let me reconsider. `...null` DOES work in JavaScript/TypeScript:
-
-```typescript
-const obj = { ...null }; // → {}
-const obj2 = { ...undefined }; // → {}
-```
-
-This is valid ES2018+ behavior. So `...existing` when existing is null simply produces `{}`. **No special handling needed.** The pattern is just:
-
-```typescript
-const existing = await resolveEntity(...) // T | null
-
-const entity = new OrbLevel({
-  ...existing,     // {} if null, all fields if not
-  id,              // always explicit (required for create case)
-  address,         // always explicit (required for create case)
-  tokenId,         // always explicit
-  value: newValue, // always explicit (the thing we're updating)
-  digitalAsset: existing?.digitalAsset ?? null,  // FK: preserve if exists, null if create
-  nft: existing?.nft ?? null,                    // FK: preserve if exists, null if create
-});
-```
-
-Hmm, but now FKs need explicit handling again. The spread carries them, but then we override them with the explicit fields. Let me think...
-
-Actually, the issue is for the **create case**: when `existing` is null, spread gives `{}`, and then we MUST provide all required fields including FKs as `null`. For the **update case**: when `existing` has values, spread carries them, and then we DON'T want to override FKs.
-
-**The cleanest approach:**
-
-```typescript
-const existing = await resolveEntity(hctx.store, hctx.batchCtx, TYPE, Class, id);
-
-if (existing) {
-  // UPDATE: spread preserves all fields, override only what changed
-  const entity = new EntityClass({ ...existing, value: newValue });
-  hctx.batchCtx.addEntity(TYPE, id, entity);
-} else {
-  // CREATE: all fields explicit, FKs null
-  const entity = new EntityClass({
-    id, address, tokenId,
-    value: newValue,
-    digitalAsset: null,
-    nft: null,
-  });
-  hctx.batchCtx.addEntity(TYPE, id, entity);
-  // Queue enrichment (only on create — existing already enriched)
-  hctx.batchCtx.queueEnrichment(...);
-}
-```
-
-This is cleaner than trying to merge create+update into one expression. The branching is explicit, the intent is clear, and enrichment only happens on create (not on every update).
-
-**But** this means enrichment isn't re-queued for existing entities from DB that may have lost their FKs. In practice, if the entity is in the DB, enrichment already ran for it. The only exception is the chillClaimed/orbsClaimed case where Phase 2 WIPES FKs — but with spread, they're preserved.
-
-**Final recommended pattern:**
+**Recommended pattern for type safety:**
 
 ```typescript
 const existing = await resolveEntity(hctx.store, hctx.batchCtx, TYPE, EntityClass, id);
 
 const entity = new EntityClass({
-  ...existing,                                    // preserves ALL fields if update; {} if create
-  id,                                             // always explicit
-  address,                                        // always explicit
-  value: newValue,                                // override what changed
+  ...(existing ?? {}),                            // Safe: spreads existing or empty object
+  id,                                             // Always explicit (required for create)
+  address,                                        // Always explicit (required for create)
+  value: newValue,                                // Override what changed
   digitalAsset: existing?.digitalAsset ?? null,   // FK: preserve or null
   nft: existing?.nft ?? null,                     // FK: preserve or null
 });
@@ -424,10 +330,20 @@ const entity = new EntityClass({
 hctx.batchCtx.addEntity(TYPE, id, entity);
 
 // Queue enrichment (idempotent — pipeline deduplicates)
-hctx.batchCtx.queueEnrichment(...);
+if (!existing) {
+  hctx.batchCtx.queueEnrichment(...);
+}
 ```
 
-FKs are explicit on every path with `existing?.fk ?? null`. This is the safest, most readable approach.
+**Key points:**
+
+1. `...(existing ?? {})` is type-safe under strict mode and readable
+2. Spread carries over ALL fields from existing entity (or nothing if create)
+3. Explicit fields after spread override what changed
+4. FKs use `existing?.fk ?? null` for clarity and to satisfy TypeScript
+5. Enrichment only queued on create (when `!existing`)
+
+This pattern works for both create and update in a single code path with clear intent.
 
 ---
 


### PR DESCRIPTION
## Summary

Research for Phase 5.3: Entity Upsert Pattern Standardization

Comprehensive audit of all 29 V2 handlers reveals **4 different ad-hoc patterns** for the same operation ("entity might already exist"). This inconsistency produced 3 confirmed bugs and 2 cross-batch FK gaps.

**Solution:** Introduce two helpers (`resolveEntity`/`resolveEntities`) and refactor all 13 handlers that do entity lookups to a single recognizable pattern:

```typescript
// RESOLVE (batch → DB → null)
const existing = await resolveEntity(hctx.store, hctx.batchCtx, TYPE, EntityClass, id);

// BUILD (spread preserves ALL fields including FKs)
const entity = new EntityClass({
  ...existing,                                  // carries over all fields (or {} if null)
  id,                                           // always explicit
  value: newValue,                              // override what this handler owns
  digitalAsset: existing?.digitalAsset ?? null, // FK: preserve if exists, null if create
});

// COMMIT
hctx.batchCtx.addEntity(TYPE, id, entity);
```

**Visual test:** When you see `...existing` in a constructor → handler is safe. When you don't → it's either create-only (fine) or a bug.

## Changes

- **ROADMAP.md** — Phase 5.3 added with 4 requirements (UPSRT-01 to UPSRT-04), dependency graph updated
- **STATE.md** — Current position updated to Phase 5.3 research complete, 34/42 requirements
- **05.3-RESEARCH.md** — Full research doc (unified pattern design, handler-by-handler refactor plan)

## Scope

| What | Count | Est. lines |
|------|-------|-----------|
| New helpers + tests | 2 functions | ~160 |
| Tier 1: Bugfix handlers | 5 (chillClaimed, orbsClaimed, lsp5ReceivedAssets, orbLevel, orbFaction) | ~90 |
| Tier 2: Standardize working | 8 (totalSupply, ownedAssets, nft, lsp4Creators, lsp12IssuedAssets, lsp6Controllers, formattedTokenId, lsp4MetadataBaseUri) | ~150 |
| Delete old helper | mergeEntitiesFromBatchAndDb | -50 |
| Update test mocks | ~10 files | ~80 |
| **Total** | 13 handlers | ~500 lines |

## Bugs Found

1. **chillClaimed/orbsClaimed** — Phase 2 verification wipes FK values (creates new entities with null FKs)
2. **lsp5ReceivedAssets** — Missing `addEntity()` call after DB merge (data silently lost)
3. **orbLevel/orbFaction** — Only check batch, miss DB (cross-batch FK gaps)

## Next Steps

Run `/gsd-plan-phase 5.3` to break research into executable plans (suggested 4 plans in 3 waves).