### PR TITLE
docs: add PR-based branching workflow for v1.1 milestone

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -116,6 +116,45 @@ V2 rewrite is feature-complete with data parity validated against V1 via automat
 - **Key V2 architecture**: Enrichment queue eliminates the populate phase — raw entities persist with null FKs, then batch UPDATE resolves references after verification
 - **Reference implementation**: `chillwhales/marketplace` has existing (non-ideal) GraphQL client, services, actions, and hooks — being standardized and extracted into `packages/react`
 
+## Branching & PR Workflow (v1.1)
+
+**Integration branch:** `refactor/indexer-v2-react`
+
+All v1.1 milestone work (Phases 7–11) merges through pull requests targeting `refactor/indexer-v2-react`. Never commit directly to this branch.
+
+**Before starting ANY plan execution:**
+
+```bash
+# 1. Fetch latest remote state
+git fetch origin
+
+# 2. Checkout and reset to latest integration branch
+git checkout refactor/indexer-v2-react
+git pull origin refactor/indexer-v2-react
+
+# 3. Create a new feature branch for this plan
+git checkout -b feat/<plan-description>
+# Examples:
+#   feat/react-package-scaffold
+#   feat/react-test-app
+#   feat/react-profile-hooks
+```
+
+**After completing a plan:**
+
+```bash
+# Push the feature branch and open a PR targeting the integration branch
+git push -u origin feat/<plan-description>
+gh pr create --base refactor/indexer-v2-react --title "<plan title>" --body "<summary>"
+```
+
+**Rules:**
+
+- One feature branch per plan (or per logical unit of work)
+- PRs always target `refactor/indexer-v2-react` — never `main`, never `refactor/indexer-v2`
+- Fetch + pull `refactor/indexer-v2-react` before branching — stale bases cause merge conflicts
+- `refactor/indexer-v2-react` is the single source of truth for all v1.1 work
+
 ## Constraints
 
 - **Data parity**: V2 must produce identical database state to V1 — validated via comparison tool

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -55,7 +55,7 @@ See `.planning/PROJECT.md` Key Decisions table for full record.
 - Two consumption patterns: client-side (TanStack Query) and server-side (next-safe-action)
 - Three consumption patterns: queries (TanStack Query), subscriptions (graphql-ws), server actions (next-safe-action)
 - GraphQL codegen from Hasura schema, types committed to repo
-- Branch: `refactor/indexer-v2-react` from `refactor/indexer-v2`
+- **Branch workflow: ALL v1.1 work merges via PRs to `refactor/indexer-v2-react`** — see PROJECT.md "Branching & PR Workflow" for full protocol
 - Reference: `chillwhales/marketplace` graphql package and web hooks (being standardized)
 - Vertical-slice approach: build Universal Profiles end-to-end first, then replicate across 10 domains
 - Minimal runtime deps — only `graphql-ws` for subscriptions; typed fetch wrapper for queries (zero query deps)
@@ -85,12 +85,13 @@ _None currently._
 ### Context for Next Session
 
 - **Roadmap complete** — 28 requirements across 5 phases (7–11)
-- **Next step:** `/gsd-plan-phase 7` to plan Package Foundation
+- **Next step:** Execute Phase 7 plans (07-01, 07-02)
 - **Phase 7 scope:** 7 FOUND-\* requirements — package scaffold, codegen, build, provider, error handling, entry points, Next.js test app
 - **Critical pitfalls to address in Phase 7:** C1 (server/client leak), C2 (broken exports), C3 (missing "use client"), C4 (QueryClient conflicts), C5 (type exposure)
 - **Research confidence:** HIGH across all dimensions — no spikes needed for Phase 7
 - **Reference implementation:** `chillwhales/marketplace` packages/graphql and apps/web/src/hooks
 - **Schema source:** `packages/typeorm/schema.graphql` → Hasura → codegen
+- **⚠️ BRANCHING:** Before executing ANY plan, fetch latest `refactor/indexer-v2-react` and create a new feature branch. PR back to `refactor/indexer-v2-react`. See PROJECT.md for full protocol.
 
 ---
 

--- a/.planning/phases/07-package-foundation/07-01-PLAN.md
+++ b/.planning/phases/07-package-foundation/07-01-PLAN.md
@@ -88,8 +88,8 @@ Output: A buildable, validatable `@lsp-indexer/react` package with correct expor
 </objective>
 
 <execution_context>
-@/home/coder/.config/opencode/get-shit-done/workflows/execute-plan.md
-@/home/coder/.config/opencode/get-shit-done/templates/summary.md
+@/home/coder/.config/Claude/get-shit-done/workflows/execute-plan.md
+@/home/coder/.config/Claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>
@@ -105,6 +105,29 @@ Key codebase references (read for conventions):
 @eslint.config.ts
 @packages/typeorm/schema.graphql (schema source for codegen fallback)
 </context>
+
+<git_workflow>
+
+## ⚠️ MANDATORY: Branch Setup Before Any Work
+
+ALL v1.1 work merges via PRs to `refactor/indexer-v2-react`. Before executing tasks:
+
+```bash
+git fetch origin
+git checkout refactor/indexer-v2-react
+git pull origin refactor/indexer-v2-react
+git checkout -b feat/react-package-scaffold
+```
+
+After all tasks complete and SUMMARY is written:
+
+```bash
+git push -u origin feat/react-package-scaffold
+gh pr create --base refactor/indexer-v2-react --title "feat: React package scaffold, codegen, error handling, client utilities" --body "<summary of changes>"
+```
+
+**Target branch for PR: `refactor/indexer-v2-react`** — NOT main, NOT refactor/indexer-v2.
+</git_workflow>
 
 <tasks>
 

--- a/.planning/phases/07-package-foundation/07-02-PLAN.md
+++ b/.planning/phases/07-package-foundation/07-02-PLAN.md
@@ -83,8 +83,8 @@ Output: A working Next.js 15 app that imports from `@lsp-indexer/react`, `@lsp-i
 </objective>
 
 <execution_context>
-@/home/coder/.config/opencode/get-shit-done/workflows/execute-plan.md
-@/home/coder/.config/opencode/get-shit-done/templates/summary.md
+@/home/coder/.config/Claude/get-shit-done/workflows/execute-plan.md
+@/home/coder/.config/Claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>
@@ -100,6 +100,29 @@ Key codebase references:
 @eslint.config.ts
 @packages/react/package.json
 </context>
+
+<git_workflow>
+
+## ⚠️ MANDATORY: Branch Setup Before Any Work
+
+ALL v1.1 work merges via PRs to `refactor/indexer-v2-react`. Before executing tasks:
+
+```bash
+git fetch origin
+git checkout refactor/indexer-v2-react
+git pull origin refactor/indexer-v2-react
+git checkout -b feat/react-test-app
+```
+
+After all tasks complete and SUMMARY is written:
+
+```bash
+git push -u origin feat/react-test-app
+gh pr create --base refactor/indexer-v2-react --title "feat: Next.js test app + end-to-end validation" --body "<summary of changes>"
+```
+
+**Target branch for PR: `refactor/indexer-v2-react`** — NOT main, NOT refactor/indexer-v2.
+</git_workflow>
 
 <tasks>
 


### PR DESCRIPTION
## Summary

- Add **Branching & PR Workflow** section to `PROJECT.md` — the authoritative reference for the entire v1.1 milestone
- All work (Phases 7–11) merges through PRs targeting `refactor/indexer-v2-react`
- Each plan execution: fetch latest → new feature branch → PR back to integration branch

## Changes

| File | Change |
|------|--------|
| `.planning/PROJECT.md` | New "Branching & PR Workflow (v1.1)" section with exact commands and rules |
| `.planning/STATE.md` | Updated decision callout + ⚠️ BRANCHING reminder in session context |
| `07-01-PLAN.md` | Added `<git_workflow>` section: branch as `feat/react-package-scaffold`, PR to `refactor/indexer-v2-react` |
| `07-02-PLAN.md` | Added `<git_workflow>` section: branch as `feat/react-test-app`, PR to `refactor/indexer-v2-react` |

Also fixed `execution_context` paths from `opencode` → `Claude` in both plans.