### PR TITLE
docs(09): restructure Phase 9 into per-domain sub-phases 9.1–9.9

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -322,17 +322,19 @@ Each domain follows the validated vertical-slice pattern from Phase 8 (profiles)
 | ----- | ---------------------------------- | :----------: | -------- |
 | 7     | Package Foundation                 |     7/7      | Complete |
 | 8     | First Vertical Slice (Profiles)    |     3/3      | Complete |
-| 9.1   | Digital Assets                     |      2       | Pending  |
-| 9.2   | NFTs                               |      2       | Pending  |
-| 9.3   | Owned Assets                       |      2       | Pending  |
-| 9.4   | Social / Follows                   |      2       | Pending  |
-| 9.5   | Creators                           |      2       | Pending  |
-| 9.6   | Encrypted Assets                   |      2       | Pending  |
-| 9.7   | Encrypted Feed                     |      2       | Pending  |
-| 9.8   | Data Changed Events                |      2       | Pending  |
-| 9.9   | Universal Receiver Events          |      2       | Pending  |
+| 9.1   | Digital Assets                     |      1       | Pending  |
+| 9.2   | NFTs                               |      1       | Pending  |
+| 9.3   | Owned Assets                       |      1       | Pending  |
+| 9.4   | Social / Follows                   |      1       | Pending  |
+| 9.5   | Creators                           |      1       | Pending  |
+| 9.6   | Encrypted Assets                   |      1       | Pending  |
+| 9.7   | Encrypted Feed                     |      1       | Pending  |
+| 9.8   | Data Changed Events                |      1       | Pending  |
+| 9.9   | Universal Receiver Events          |      1       | Pending  |
 | 10    | Subscriptions                      |      3       | Pending  |
 | 11    | Server Actions & Publish Readiness |      4       | Pending  |
+
+_Note:_ Phase 9 has 10 requirements total: 9 QUERY requirements (one per sub-phase) plus PAGE-01 which is delivered incrementally across all sub-phases and counted once globally.
 
 **Total:** 10/28 requirements delivered
 
@@ -343,16 +345,18 @@ Each domain follows the validated vertical-slice pattern from Phase 8 (profiles)
 ```
 Phase 7 (Package Foundation)
   └──→ Phase 8 (First Vertical Slice — Universal Profiles + 4-package split)
-         └──→ Phase 9.1 (Digital Assets)
-         └──→ Phase 9.2 (NFTs)
-         └──→ Phase 9.3 (Owned Assets)
-         └──→ Phase 9.4 (Social / Follows)
-         └──→ Phase 9.5 (Creators)
-         └──→ Phase 9.6 (Encrypted Assets)
-         └──→ Phase 9.7 (Encrypted Feed)
-         └──→ Phase 9.8 (Data Changed Events)
-         └──→ Phase 9.9 (Universal Receiver Events)
-                ├──→ Phase 10 (Subscriptions) — after all 9.x complete
+         └──→ Phase 9 (Remaining Query Domains — all sub-phases independent)
+                ├──→ 9.1 (Digital Assets)
+                ├──→ 9.2 (NFTs)
+                ├──→ 9.3 (Owned Assets)
+                ├──→ 9.4 (Social / Follows)
+                ├──→ 9.5 (Creators)
+                ├──→ 9.6 (Encrypted Assets)
+                ├──→ 9.7 (Encrypted Feed)
+                ├──→ 9.8 (Data Changed Events)
+                └──→ 9.9 (Universal Receiver Events)
+                       ↓ (all 9.x must complete)
+                ├──→ Phase 10 (Subscriptions)
                 └──→ Phase 11 (Server Actions & Publish Readiness) ←── also depends on Phase 10
 ```
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -30,17 +30,19 @@ Archives: `.planning/milestones/v1.0-ROADMAP.md`, `.planning/milestones/v1.0-REQ
 | ----- | ---------------------------------- | :----------: | -------- |
 | 7     | Package Foundation                 |     7/7      | Complete |
 | 8     | First Vertical Slice (Profiles)    |     3/3      | Complete |
-| 9.1   | Digital Assets                     |      2       | Pending  |
-| 9.2   | NFTs                               |      2       | Pending  |
-| 9.3   | Owned Assets                       |      2       | Pending  |
-| 9.4   | Social / Follows                   |      2       | Pending  |
-| 9.5   | Creators                           |      2       | Pending  |
-| 9.6   | Encrypted Assets                   |      2       | Pending  |
-| 9.7   | Encrypted Feed                     |      2       | Pending  |
-| 9.8   | Data Changed Events                |      2       | Pending  |
-| 9.9   | Universal Receiver Events          |      2       | Pending  |
+| 9.1   | Digital Assets                     |      1       | Pending  |
+| 9.2   | NFTs                               |      1       | Pending  |
+| 9.3   | Owned Assets                       |      1       | Pending  |
+| 9.4   | Social / Follows                   |      1       | Pending  |
+| 9.5   | Creators                           |      1       | Pending  |
+| 9.6   | Encrypted Assets                   |      1       | Pending  |
+| 9.7   | Encrypted Feed                     |      1       | Pending  |
+| 9.8   | Data Changed Events                |      1       | Pending  |
+| 9.9   | Universal Receiver Events          |      1       | Pending  |
 | 10    | Subscriptions                      |      3       | Pending  |
 | 11    | Server Actions & Publish Readiness |      4       | Pending  |
+
+_Note:_ Phase 9 has 10 requirements total: 9 QUERY requirements (one per sub-phase) plus PAGE-01 which is delivered incrementally across all sub-phases and counted once globally.
 
 **Total:** 10/28 requirements delivered (FOUND-01–07, QUERY-01, DX-01, DX-02)
 


### PR DESCRIPTION
## Summary

- Split monolithic Phase 9 (11 plans, 1 phase) into 9 independent sub-phases (9.1–9.9), one per query domain
- Each sub-phase follows Phase 8's 4-plan vertical-slice pattern (types+docs+codegen → parsers+services+keys → hooks+actions+wiring → playground+verification)
- Each sub-phase gets its own branch and PR for granular review
- Add build artifacts to `.gitignore` (tsup bundled configs, `next-env.d.ts`, `.next/`)
- Remove tracked `apps/test/next-env.d.ts`

## Sub-phases

| Sub-phase | Domain | Requirement |
|-----------|--------|-------------|
| 9.1 | Digital Assets | QUERY-02 |
| 9.2 | NFTs | QUERY-03 |
| 9.3 | Owned Assets | QUERY-04 |
| 9.4 | Social / Follows | QUERY-05 |
| 9.5 | Creators | QUERY-06 |
| 9.6 | Encrypted Assets | QUERY-07 |
| 9.7 | Encrypted Feed | QUERY-08 |
| 9.8 | Data Changed Events | QUERY-09 |
| 9.9 | Universal Receiver Events | QUERY-10 |

Replaces closed PRs #187–#190 (timeline-based splits that lacked domain granularity).