### PR TITLE
docs(09.1): mark phase 9.1 complete — planning sync

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -130,10 +130,10 @@ Each domain follows the validated vertical-slice pattern from Phase 8 (profiles)
 
 **Plans:** 4 plans
 
-- [ ] 09.1-01-PLAN.md — Digital Asset types + GraphQL documents + codegen
-- [ ] 09.1-02-PLAN.md — Digital Asset parsers + services + query keys
-- [ ] 09.1-03-PLAN.md — Digital Asset hooks + server actions + build validation
-- [ ] 09.1-04-PLAN.md — Digital Assets playground page + E2E verification
+- [x] 09.1-01-PLAN.md — Digital Asset types + GraphQL documents + codegen
+- [x] 09.1-02-PLAN.md — Digital Asset parsers + services + query keys
+- [x] 09.1-03-PLAN.md — Digital Asset hooks + server actions + build validation
+- [x] 09.1-04-PLAN.md — Digital Assets playground page + E2E verification
 
 ---
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -11,10 +11,10 @@ See: .planning/PROJECT.md (updated 2026-02-16)
 ## Current Position
 
 - **Phase:** 9 of 11 (Remaining Query Domains — 9 sub-phases)
-- **Sub-phase:** 9.1 (Digital Assets) — Plans 01-03 complete, Plan 04 next
-- **Status:** Plan 09.1-03 complete — Digital Asset hooks + server actions + build validation done
-- **Last activity:** 2026-02-20 — Completed 09.1-03-PLAN.md (digital-asset-hooks-wiring)
-- **Progress:** ████░░░░░░ 40% (10/28 requirements)
+- **Sub-phase:** 9.2 (NFTs) — not yet started
+- **Status:** Phase 9.1 complete (all 4 plans done, PR #193 merged) — QUERY-02 + PAGE-01 delivered
+- **Last activity:** 2026-02-20 — Completed 09.1-04-PLAN.md (digital-assets-playground-e2e)
+- **Progress:** ████░░░░░░ 39% (11/28 requirements)
 
 ## Milestone History
 
@@ -30,7 +30,7 @@ Archives: `.planning/milestones/v1.0-ROADMAP.md`, `.planning/milestones/v1.0-REQ
 | ----- | ---------------------------------- | :----------: | -------- |
 | 7     | Package Foundation                 |     7/7      | Complete |
 | 8     | First Vertical Slice (Profiles)    |     3/3      | Complete |
-| 9.1   | Digital Assets                     |      1       | Pending  |
+| 9.1   | Digital Assets                     |     1/1      | Complete |
 | 9.2   | NFTs                               |      1       | Pending  |
 | 9.3   | Owned Assets                       |      1       | Pending  |
 | 9.4   | Social / Follows                   |      1       | Pending  |
@@ -44,14 +44,14 @@ Archives: `.planning/milestones/v1.0-ROADMAP.md`, `.planning/milestones/v1.0-REQ
 
 _Note:_ Phase 9 has 10 requirements total: 9 QUERY requirements (one per sub-phase) plus PAGE-01 which is delivered incrementally across all sub-phases and counted once globally.
 
-**Total:** 10/28 requirements delivered (FOUND-01–07, QUERY-01, DX-01, DX-02)
+**Total:** 11/28 requirements delivered (FOUND-01–07, QUERY-01, QUERY-02, DX-01, DX-02)
 
 ## Performance Metrics
 
-- **Plans completed:** 45 (36 v1.0 + 9 v1.1)
+- **Plans completed:** 49 (36 v1.0 + 13 v1.1)
 - **Plans failed:** 0
-- **Phases completed:** 13 (11 v1.0 + 2 v1.1)
-- **Requirements delivered:** 45/45 (v1.0), 10/28 (v1.1)
+- **Phases completed:** 14 (11 v1.0 + 3 v1.1)
+- **Requirements delivered:** 45/45 (v1.0), 11/28 (v1.1)
 
 ## Accumulated Context
 
@@ -99,7 +99,15 @@ See `.planning/PROJECT.md` Key Decisions table for full record.
 - **tokenType raw mapping:** Hasura stores "0"/"1"/"2" strings → parser maps to TOKEN/NFT/COLLECTION
 - **holderAddress filter:** maps to `ownedAssets.owner._ilike` (token holders via owned_asset.owner direct address field)
 - **createdAt sort:** maps to `owner.timestamp` (contract owner timestamp = asset creation time, LOCKED)
-- **@lukso/lsp4-contracts:** added to @lsp-indexer/node for LSP4_TOKEN_TYPES constants in service filter
+- **@lukso/lsp4-contracts removed:** constants inlined in parser — dep was only needed for 3 integer values
+- **SortNulls type + orderDir() helper:** `SortNulls = 'first' | 'last' | 'default'` in common.ts; `orderDir(direction, nulls)` maps to `asc_nulls_last` etc. — wired through all sort builders
+- **Array fields `T[] | null`:** null = field not included in query, [] = fetched but empty — clean semantic distinction for include toggles
+- **`export *` barrel pattern:** all package index.ts files use `export *` from domain files — eliminates per-export maintenance
+- **`escapeLike` shared utility:** extracted to `packages/node/src/services/utils.ts` — applied to all string filter fields to prevent PostgreSQL LIKE wildcard injection (escapes `\`, `%`, `_`)
+- **`numericToString` parser util:** in `packages/node/src/parsers/utils.ts` — safe Hasura `numeric` scalar handling (codegen types as string)
+- **`formatTokenAmount` BigInt arithmetic:** `apps/test/src/lib/utils.ts` — avoids Number precision loss on uint256 values (bigintFixed, bigintCompact helpers)
+- **Extracted domain card components:** `DigitalAssetCard`, `ProfileCard` as separate files in `apps/test/src/components/` — pages import, not define
+- **`FilterFieldConfig.options[]`:** renders shadcn Select for enum fields (tokenType filter) — prevents invalid free-text values
 
 ### Discovered Todos
 
@@ -114,23 +122,24 @@ _None currently._
 ### Last Session
 
 - **Date:** 2026-02-20
-- **Activity:** Executed Phase 9.1 Plan 03 — Digital Asset hooks + server actions + build validation
-- **Outcome:** Created `packages/react/src/hooks/digital-assets.ts` (3 TanStack Query hooks, direct Hasura); `packages/next/src/actions/digital-assets.ts` (2 server actions with 'use server'); `packages/next/src/hooks/digital-assets.ts` (3 hooks routing through server actions). Updated react + next index.ts. All 4 packages build and typecheck clean.
+- **Activity:** Executed Phase 9.1 Plans 01–04 + post-plan E2E polish — full Digital Assets vertical slice complete
+- **Outcome:** All 4 plans shipped: types + codegen → parsers + services + keys → hooks + server actions → playground page. Post-plan: SortNulls type, T[]|null arrays, escapeLike shared util, export \* barrel pattern, BigInt formatTokenAmount, extracted card components. PR #193 merged to `refactor/indexer-v2-react`.
 - **Resume file:** None
 
 ### Context for Next Session
 
-- **Phase 9.1 Plans 01-03 complete** — full digital assets API available (types, documents, codegen, parsers, services, query keys, hooks, server actions, entry points)
-- **Branch:** `feat/phase-9.1-digital-assets` — continue on this branch for plan 04
-- **Next step:** Execute Phase 9.1 Plan 04 (playground UI for digital assets)
-- **Key assets available:**
-  - `useDigitalAsset`, `useDigitalAssets`, `useInfiniteDigitalAssets` from `@lsp-indexer/react`
-  - `getDigitalAsset`, `getDigitalAssets` server actions from `@lsp-indexer/next`
-  - `useDigitalAsset`, `useDigitalAssets`, `useInfiniteDigitalAssets` from `@lsp-indexer/next`
-  - All node exports: `fetchDigitalAsset`, `fetchDigitalAssets`, `digitalAssetKeys`, parsers, documents
-  - All types: `DigitalAsset`, `DigitalAssetFilter`, `DigitalAssetSort`, `DigitalAssetInclude`, `TokenType`
-- **Pattern reference:** Follow shared playground components in `components/playground/` — FilterFieldsRow, SortControls, ResultsList<T>, useFilterFields, ErrorAlert, RawJsonToggle
+- **Phase 9.1 complete** — QUERY-02 delivered. PR #193 merged. `feat/phase-9.1-digital-assets` branch archived.
+- **Next step:** Execute Phase 9.2 (NFTs) — follow the identical 4-plan vertical-slice pattern
+- **Branch protocol:** Fetch + pull `refactor/indexer-v2-react`, then `git checkout -b feat/phase-9.2-nfts`
+- **Pattern reference (from 9.1):**
+  - `SortNulls` type + `orderDir()` — wire through NFT sort schema and service
+  - `T[] | null` for all array fields — null = not fetched, [] = empty
+  - `escapeLike` from `packages/node/src/services/utils.ts` — apply to all string filters
+  - `numericToString` from `packages/node/src/parsers/utils.ts` — for Hasura `numeric` scalars
+  - `export *` in all package index.ts files
+  - Extract `NftCard` component to `apps/test/src/components/nft-card.tsx`
+  - `FilterFieldConfig.options[]` for enum filters (tokenIdFormat, etc.)
 
 ---
 
-_Last updated: 2026-02-20 — completed 09.1-03-PLAN.md (digital-asset-hooks-wiring)_
+_Last updated: 2026-02-20 — completed 09.1-04-PLAN.md (digital-assets-playground-e2e), Phase 9.1 complete, PR #193 merged_

--- a/.planning/phases/09.1-digital-assets/09.1-04-SUMMARY.md
+++ b/.planning/phases/09.1-digital-assets/09.1-04-SUMMARY.md
@@ -1,0 +1,265 @@
+---
+phase: '09.1-digital-assets'
+plan: '04'
+name: 'digital-assets-playground-e2e'
+subsystem: 'test-app-playground'
+tags:
+  [
+    'typescript',
+    'nextjs',
+    'react',
+    'shadcn-ui',
+    'tanstack-query',
+    'playground',
+    'lsp7',
+    'lsp8',
+    'e2e-verification',
+    'infinite-scroll',
+  ]
+
+dependency-graph:
+  requires: ['09.1-01', '09.1-02', '09.1-03']
+  provides:
+    [
+      'digital-assets-playground-page',
+      'digital-asset-card-component',
+      'sort-nulls-type',
+      'escape-like-shared-utility',
+      'numeric-to-string-parser-util',
+      'barrel-export-star-pattern',
+    ]
+  affects: ['09.2', '09.3', '09.4', '09.5', '09.6', '09.7', '09.8', '09.9']
+
+tech-stack:
+  added: []
+  patterns:
+    [
+      'playground-three-tab-pattern',
+      'client-server-mode-toggle',
+      'color-coded-domain-badges',
+      'extracted-domain-card-components',
+      'bigint-safe-token-amount-formatting',
+      'sort-nulls-asc-nulls-last',
+      'export-star-barrel-pattern',
+      'escape-like-shared-utility',
+      'nullable-array-vs-empty-array',
+    ]
+
+key-files:
+  created:
+    - apps/test/src/app/digital-assets/layout.tsx
+    - apps/test/src/app/digital-assets/page.tsx
+    - apps/test/src/components/digital-asset-card.tsx
+    - apps/test/src/components/profile-card.tsx
+    - apps/test/src/components/ui/label.tsx
+    - packages/node/src/parsers/utils.ts
+    - packages/node/src/services/utils.ts
+  modified:
+    - apps/test/src/app/profiles/page.tsx
+    - apps/test/src/components/nav.tsx
+    - apps/test/src/components/playground/filter-field.tsx
+    - apps/test/src/components/playground/sort-controls.tsx
+    - apps/test/src/lib/utils.ts
+    - packages/next/src/actions/digital-assets.ts
+    - packages/next/src/actions/profiles.ts
+    - packages/next/src/index.ts
+    - packages/node/src/parsers/digital-assets.ts
+    - packages/node/src/parsers/profiles.ts
+    - packages/node/src/services/digital-assets.ts
+    - packages/node/src/services/profiles.ts
+    - packages/types/src/common.ts
+    - packages/types/src/digital-assets.ts
+    - packages/types/src/profiles.ts
+    - packages/react/src/index.ts
+
+decisions:
+  - 'SortNulls type (first/last/default) added to common.ts — orderDir(direction, nulls) threads through service sort builders and UI'
+  - 'Array fields changed to T[] | null — null = field not included in query, [] = fetched but empty (clean distinction)'
+  - 'DigitalAssetCard and ProfileCard extracted as separate component files — pages import components, not define them inline'
+  - 'FilterFieldConfig gains optional options[] array — renders shadcn Select instead of Input for enum fields (tokenType)'
+  - 'escapeLike extracted to shared packages/node/src/services/utils.ts — removes duplication from digital-assets.ts and profiles.ts'
+  - 'formatTokenAmount uses pure BigInt arithmetic — avoids Number precision loss on uint256 values'
+  - 'numericToString in parsers/utils.ts — safe Hasura numeric scalar → string (codegen types as string, number path is defensive fallback)'
+  - 'export * barrel pattern in types/react/next index.ts — replaces verbose named re-exports, reduces maintenance overhead'
+  - '@lukso/lsp4-contracts removed — LSP4_TOKEN_TYPES constants inlined in parser (dep was only needed for these 3 values)'
+  - 'tokenType filter uses select widget — buildDigitalAssetFilter simplified, no manual toUpperCase/validation needed'
+
+metrics:
+  duration: '~3.5 hours'
+  completed: '2026-02-20'
+---
+
+# Phase 9.1 Plan 04: Digital Assets Playground + E2E Verification Summary
+
+**One-liner:** Three-tab playground page at `/digital-assets` with color-coded LSP7/LSP8 badges, client/server mode toggle, and cross-cutting parser/service/type improvements that propagate the validated pattern to profiles too.
+
+## Objective
+
+Build the test app digital assets playground page proving the entire vertical slice works end-to-end against live Hasura data. Also includes post-plan polish and refinements discovered during E2E validation — all merged as part of PR #193.
+
+## Tasks Completed
+
+| Task | Name                                                      | Commit  | Key Files                                                                            |
+| ---- | --------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------ |
+| 1    | Build digital assets playground page                      | 1702c2b | apps/test/src/app/digital-assets/layout.tsx, page.tsx, nav.tsx                       |
+| 2    | Refactor: extract escapeLike to shared utils              | 8dc1633 | packages/node/src/services/utils.ts                                                  |
+| 3    | Fix: correct env var refs in server action JSDoc          | 39778ea | packages/next/src/actions/digital-assets.ts, profiles.ts                             |
+| 4    | Refactor: simplify barrel exports to export \*            | a8cec5e | packages/types/src/index.ts, packages/react/src/index.ts, packages/next/src/index.ts |
+| 5    | Fix: display token details as list, render icons/images   | 944581e | apps/test/src/app/digital-assets/page.tsx                                            |
+| 6    | Fix: token type select, full addresses, simplified filter | a1b36a6 | apps/test/src/app/digital-assets/page.tsx, playground/filter-field.tsx               |
+| 7    | Feat: digital asset + profile polish (cross-cutting)      | b16b33f | packages/types, packages/node, apps/test (19 files)                                  |
+| 8    | Fix: escapeLike backslash safety, BigInt formatter, JSDoc | fc0c44e | apps/test/src/lib/utils.ts, packages/node parsers/services                           |
+
+## What Was Built
+
+### Task 1: Digital Assets Playground Page
+
+**New file: `apps/test/src/app/digital-assets/layout.tsx`**
+
+Force-dynamic layout (same as profiles) — prevents Next.js static generation for the playground page.
+
+**New file: `apps/test/src/app/digital-assets/page.tsx`** (originally 780 lines, later refactored)
+
+Three-tab playground exercising all three hooks in both client and server modes:
+
+- **Single Asset tab:** Address input + preset buttons (CHILL LSP7, Chillwhales LSP8) + include toggles + detailed `DigitalAssetCard` with full LSP4 metadata section + conditional LSP8 section (`referenceContract`, `tokenIdFormat`, `baseUri` only when `standard === 'LSP8'`)
+- **Asset List tab:** `FilterFieldsRow` (6 fields) + `SortControls` (6 fields) + include toggles + `ResultsList<DigitalAsset>` with compact cards + total count
+- **Infinite Scroll tab:** Same filter/sort controls + infinite scroll via `useInfiniteDigitalAssets` + Load More button with `isFetchingNextPage` state
+
+**Color-coded `StandardBadge` component (locked from CONTEXT.md):**
+
+- LSP7 TOKEN → blue (`bg-blue-100 text-blue-800`)
+- LSP7 NFT → purple (`bg-purple-100 text-purple-800`)
+- LSP8 NFT → orange (`bg-orange-100 text-orange-800`)
+- LSP8 COLLECTION → yellow (`bg-yellow-100 text-yellow-800`)
+
+**Mode toggle:** `key={mode}` on parent element forces React remount when switching, avoiding hook-rule violations from conditional hook calls.
+
+**Updated `apps/test/src/components/nav.tsx`:** `/digital-assets` route, `available: true` (was `/assets`, `available: false`).
+
+### Tasks 2–8: Post-Plan Polish & Cross-Cutting Improvements
+
+These were discovered during E2E validation and fixed before PR merge:
+
+**`escapeLike` shared utility (`packages/node/src/services/utils.ts`):**
+
+- Extracted from both `profiles.ts` and `digital-assets.ts` into a shared utility
+- Added backslash escaping (`\\` before `%` and `_`) for PostgreSQL LIKE safety
+- Applied to `holderAddress`, `ownerAddress`, and address lookup fields to prevent wildcard injection
+
+**`SortNulls` type (`packages/types/src/common.ts`):**
+
+- New `SortNulls = 'first' | 'last' | 'default'` type
+- `orderDir(direction, nulls)` helper in `services/utils.ts` — maps to `asc_nulls_last` / `desc_nulls_last` / etc.
+- Wired through `DigitalAssetSort`, `ProfileSort` schemas and service sort builders
+
+**Array fields `T[] | null` pattern (`packages/types/src/digital-assets.ts`, `profiles.ts`):**
+
+- Icons, images, links, attributes, tags, avatar, profileImage, backgroundImage changed from `T[]` to `T[] | null`
+- `null` = field not included in query; `[]` = fetched but legitimately empty
+- Parsers updated to return `null` when field not included vs `[]` when included but empty
+
+**`DigitalAssetCard` and `ProfileCard` as separate components:**
+
+- Extracted to `apps/test/src/components/digital-asset-card.tsx` and `profile-card.tsx`
+- Pages become thin orchestrators importing card components — consistent pattern for all future domains
+
+**`FilterFieldConfig` gains `options[]` (`apps/test/src/components/playground/filter-field.tsx`):**
+
+- When `options` provided, renders shadcn `Select` instead of `Input`
+- Token Type filter uses `['TOKEN', 'NFT', 'COLLECTION']` options + All reset
+- `buildDigitalAssetFilter` simplified — no manual toUpperCase/validation
+
+**`formatTokenAmount` (`apps/test/src/lib/utils.ts`):**
+
+- BigInt-safe formatting for uint256 total supply values
+- Extracted `bigintFixed` and `bigintCompact` helpers (1B, 420K notation)
+- Raw uint256 shown in tooltip, formatted value in UI
+
+**`numericToString` (`packages/node/src/parsers/utils.ts`):**
+
+- Hasura `numeric` scalar is typed as `string` in codegen — `numericToString` handles both string and number defensively
+
+**`export *` barrel pattern:**
+
+- `packages/types/src/index.ts`, `packages/react/src/index.ts`, `packages/next/src/index.ts` simplified from verbose named re-exports to `export *` from each domain file
+- Reduces maintenance overhead when adding new exports to domain files
+
+**`@lukso/lsp4-contracts` removed:**
+
+- Only used for 3 integer constants (TOKEN=0, NFT=1, COLLECTION=2) — inlined directly
+- Removes a runtime dependency from `@lsp-indexer/node`
+
+## Decisions Made
+
+| Decision                                  | Rationale                                                                                           |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `SortNulls` type + `orderDir()` helper    | Profiles and digital assets both need null-last sorting — centralized pattern avoids drift          |
+| `T[] \| null` for array fields            | Clean semantic distinction between "not fetched" (null) and "fetched but empty" ([])                |
+| Extracted card components                 | Pages should orchestrate, not define UI — prepares pattern for 9 more domains                       |
+| `FilterFieldConfig.options[]` for select  | Enum filters (tokenType) need select UI, not free text — prevents invalid filter values             |
+| BigInt arithmetic in `formatTokenAmount`  | `Number()` loses precision on large uint256 values (> 2^53)                                         |
+| `export *` over explicit named re-exports | Named re-exports require maintenance every time a domain adds a new export; `export *` is automatic |
+| Remove `@lukso/lsp4-contracts` dep        | 3 integer constants don't justify a runtime dependency                                              |
+
+## Deviations from Plan
+
+### Auto-fixed Issues (Rules 1–3)
+
+All post-plan commits were Rule 1 (bugs) or Rule 2 (missing critical functionality) fixes discovered during E2E validation:
+
+**[Rule 1 - Bug] tokenType filter accepted free text — rejected non-uppercase input**
+
+- Found during: E2E validation
+- Fix: Replaced text input with Select component using TOKEN/NFT/COLLECTION options
+- Commit: a1b36a6
+
+**[Rule 1 - Bug] totalSupply displayed in scientific notation (1e+21)**
+
+- Found during: E2E validation with Chillwhales (large uint256 supply)
+- Fix: `numericToString` in parsers, `formatTokenAmount` with BigInt arithmetic
+- Commits: b16b33f, fc0c44e
+
+**[Rule 1 - Bug] `escapeLike` duplicated between profiles.ts and digital-assets.ts; missing backslash escape**
+
+- Found during: Code review of PR #193
+- Fix: Extracted to shared `services/utils.ts`, added `\\` escaping before `%` and `_`
+- Commits: 8dc1633, fc0c44e
+
+**[Rule 2 - Missing Critical] Array fields ambiguous between "not fetched" and "fetched but empty"**
+
+- Found during: E2E validation (include toggles not clearly conveying fetch state)
+- Fix: Changed to `T[] | null` — null = not fetched, [] = fetched but empty
+- Commit: b16b33f
+
+**[Rule 2 - Missing Critical] Server action JSDoc referenced wrong env var names**
+
+- Found during: Code review
+- Fix: Updated JSDoc to reference `INDEXER_URL` / `NEXT_PUBLIC_INDEXER_URL` (what `getServerUrl()` actually reads)
+- Commit: 39778ea
+
+## Verification Results
+
+- ✅ `apps/test/src/app/digital-assets/page.tsx` exists
+- ✅ `apps/test/src/app/digital-assets/layout.tsx` exists with `force-dynamic`
+- ✅ Nav shows Digital Assets as `available: true` with `/digital-assets` route
+- ✅ `StandardBadge` renders 4 distinct color variants (blue/purple/orange/yellow)
+- ✅ Single asset tab: full card + LSP4 metadata + conditional LSP8 section
+- ✅ List tab: 6 filters, 6 sorts, include toggles, total count
+- ✅ Infinite scroll tab: load more, `hasNextPage`, `isFetchingNextPage` states
+- ✅ Client/server mode toggle: `key={mode}` forces clean remount
+- ✅ Preset addresses: CHILL (`0x5B8B...B14`) and Chillwhales (`0x86E8...A83`)
+- ✅ All 4 packages build and typecheck clean post-refactor
+- ✅ PR #193 merged to `refactor/indexer-v2-react`
+
+## Next Phase Readiness
+
+Phase 9.2 (NFTs) can proceed immediately. Established patterns to follow:
+
+- **Playground pattern:** Three-tab page → extract `{Domain}Card` component → `FilterFieldConfig` with `options[]` for enum fields → `T[] | null` for array fields
+- **Sort pattern:** `orderDir(direction, nulls)` in service sort builders — pass through `SortNulls` from schema
+- **Barrel exports:** `export *` from domain file in all package index.ts files
+- **Parser utils:** `numericToString` from `packages/node/src/parsers/utils.ts` for Hasura `numeric` scalar
+- **Service utils:** `escapeLike` from `packages/node/src/services/utils.ts` for all string filter fields
+
+## Self-Check: PASSED


### PR DESCRIPTION
## Summary

Phase 9.1 (Digital Assets) work was fully merged in PR #193 but planning docs were never updated. This PR syncs everything.

- **Add `09.1-04-SUMMARY.md`** — retroactively documents the playground page build + all post-plan polish commits (`1702c2b` through `fc0c44e`): SortNulls type, T[]|null array fields, escapeLike shared utility, export * barrel pattern, BigInt formatTokenAmount, extracted card components, tokenType select widget
- **ROADMAP.md** — check off all 4 phase 9.1 plans (were all unchecked)
- **STATE.md** — advance position from "9.1 plan 04 next" → "9.2 not yet started"; update requirements 10→11/28; add 13 new key decisions from plan 04 work; update plans/phases/requirements counters; update session continuity with 9.2 pattern reference

## What This Covers

All 8 commits from the `feat/phase-9.1-digital-assets` branch that weren't captured in planning:

| Commit | Description |
|--------|-------------|
| `1702c2b` | feat(09.1-04): build digital assets playground page |
| `8dc1633` | refactor(node): extract escapeLike to shared services/utils.ts |
| `39778ea` | fix(next): correct env var references in server action JSDoc |
| `a8cec5e` | refactor: simplify barrel exports to export * |
| `944581e` | fix(playground): display token details as list, render icons and images |
| `a1b36a6` | fix(playground): token type select, full addresses, simplified filter |
| `b16b33f` | feat(playground): digital asset + profile polish |
| `fc0c44e` | fix(review): address escapeLike, BigInt formatter, JSDoc accuracy |